### PR TITLE
Clean-up build and cleanup of svlib (Resolve #7)

### DIFF
--- a/mk/Common.mk
+++ b/mk/Common.mk
@@ -725,12 +725,25 @@ spike_lib: $(SPIKE_FESVR_LIB).so $(SPIKE_RISCV_LIB).so
 ###############################################################################
 # Build SVLIB DPI
 
+SVLIB_PKG        := $(CORE_V_VERIF)/vendor_lib/verilab/svlib
+export SVLIB_PKG  = $(CORE_V_VERIF)/vendor_lib/verilab/svlib
+
+
 SVLIB_SRC    = $(SVLIB_PKG)/svlib/src/dpi/svlib_dpi.c
 SVLIB_CFLAGS = -shared -fPIC
 SVLIB_LIB    = $(SVLIB_PKG)/../svlib_dpi.so
 SVLIB_CXX    = gcc
 
+clone_svlib: $(SVLIB_PKG)
+
 svlib: $(SVLIB_PKG)
+
+clean_svlib:
+	rm -rf $(SVLIB_LIB)
+	rm -rf $(SVLIB_PKG)
+
+$(SVLIB_PKG):
+	$(CLONE_SVLIB_CMD)
 	@echo "$(BANNER)"
 	@echo "Building $(SVLIB_PKG)"
 	@echo "$(BANNER)"

--- a/mk/uvmt/uvmt.mk
+++ b/mk/uvmt/uvmt.mk
@@ -179,20 +179,19 @@ export COREV_DV_ROOT         = $(COREVDV_PKG)
 export CV_CORE_COREV_DV_ROOT = $(CV_CORE_COREVDV_PKG)
 
 # RISC-V Foundation's RISC-V Compliance Test-suite
-COMPLIANCE_PKG   := $(CORE_V_VERIF)/$(CV_CORE_LC)/vendor_lib/riscv/riscv-compliance
+COMPLIANCE_PKG := $(CORE_V_VERIF)/$(CV_CORE_LC)/vendor_lib/riscv/riscv-compliance
 
 # EMBench benchmarking suite
-EMBENCH_PKG	:= $(CORE_V_VERIF)/$(CV_CORE_LC)/vendor_lib/embench
-EMBENCH_TESTS	:= $(CORE_V_VERIF)/$(CV_CORE_LC)/tests/programs/embench
+EMBENCH_PKG    := $(CORE_V_VERIF)/$(CV_CORE_LC)/vendor_lib/embench
+EMBENCH_TESTS  := $(CORE_V_VERIF)/$(CV_CORE_LC)/tests/programs/embench
 
 # Disassembler
-#DPI_DASM_PKG       := $(CORE_V_VERIF)/lib/dpi_dasm
-#DPI_DASM_SPIKE_PKG := $(CORE_V_VERIF)/$(CV_CORE_LC)/vendor_lib/dpi_dasm_spike
-DPI_DASM_PKG       := $(CV_VERIF_PKG)/lib/dpi_dasm
-DPI_DASM_SPIKE_PKG := $(CV_VERIF_PKG)/vendor_lib/dpi_dasm_spike
-export DPI_DASM_PKG        = $(CV_VERIF_PKG)/lib/dpi_dasm
-export DPI_DASM_ROOT       = $(DPI_DASM_PKG)
-export DPI_DASM_SPIKE_ROOT = $(DPI_DASM_SPIKE_PKG)
+DPI_DASM_PKG               := $(CV_VERIF_PKG)/lib/dpi_dasm
+DPI_DASM_SPIKE_PKG         := $(CV_VERIF_PKG)/vendor_lib/dpi_dasm_spike
+export DPI_DASM_PKG         = $(CV_VERIF_PKG)/lib/dpi_dasm
+export DPI_DASM_SPIKE_PKG   = $(CV_VERIF_PKG)/vendor_lib/dpi_dasm_spike
+export DPI_DASM_ROOT        = $(DPI_DASM_PKG)
+export DPI_DASM_SPIKE_ROOT  = $(DPI_DASM_SPIKE_PKG)
 
 # TB source files for the CV32E core
 #TBSRC_HOME  := $(CORE_V_VERIF)/$(CV_CORE_LC)/tb
@@ -214,12 +213,6 @@ export DESIGN_RTL_DIR = $(CV_CORE_PKG)/rtl
 
 RTLSRC_HOME   := $(CV_CORE_PKG)/rtl
 RTLSRC_INCDIR := $(RTLSRC_HOME)/include
-
-# SVLIB
-#SVLIB_PKG        := $(CORE_V_VERIF)/$(CV_CORE_LC)/vendor_lib/verilab/svlib
-#export SVLIB_PKG  = $(CORE_V_VERIF)/$(CV_CORE_LC)/vendor_lib/verilab/svlib
-SVLIB_PKG        := $(CORE_V_VERIF)/vendor_lib/verilab/svlib
-export SVLIB_PKG  = $(CORE_V_VERIF)/vendor_lib/verilab/svlib
 
 # CORE-V-VERIF
 #CV_VERIF_PKG        := $(CORE_V_VERIF)/$(CV_CORE_LC)/vendor_lib/openhwgroup_core-v-verif
@@ -271,8 +264,6 @@ clone_compliance: $(COMPLIANCE_PKG)
 clone_dpi_dasm_spike:
 	$(CLONE_DPI_DASM_SPIKE_CMD)
 
-clone_svlib: $(SVLIB_PKG)
-
 $(CV_CORE_PKG):
 	$(CLONE_CV_CORE_CMD)
 
@@ -287,9 +278,6 @@ $(EMBENCH_PKG):
 
 $(DPI_DASM_SPIKE_PKG):
 	$(CLONE_DPI_DASM_SPIKE_CMD)
-
-$(SVLIB_PKG):
-	$(CLONE_SVLIB_CMD)
 
 $(CV_VERIF_PKG):
 	$(CLONE_CV_VERIF_CMD)
@@ -456,7 +444,8 @@ endif
 endif
 
 ################################################################################
-# Display all the shell env vars defined here (handy debug tool).
+# Display all the shell env vars defined in the Makefiles (handy debug tool).
+# Note that some of these vars may be defined in 'included' Makefiles.
 echo_env:
 	@echo "ENV vars set in uvmt.mk:"
 	@echo "   CV_CORE_LC                        = $(CV_CORE_LC)"
@@ -531,9 +520,6 @@ clean_embench:
 
 clean_dpi_dasm_spike:
 	rm -rf $(DPI_DASM_SPIKE_PKG)
-
-clean_svlib:
-	rm -rf $(SVLIB_PKG)
 
 clean_core_v_verif:
 	rm -rf $(CV_VERIF_PKG)

--- a/vendor_lib/verilab/README.md
+++ b/vendor_lib/verilab/README.md
@@ -22,12 +22,12 @@ From any class or module simply address or import the svlib_pkg to access the SV
 
 ## Shared Library
 
-SVLIB is partially implemented in C accessed via the DPI in SystemVerilog.  A checked-in shared object (compile to Linux 64-bit) will enable
-out-of-the-box operation for most users.  However if one needs to recompile the SVLIB DPI this can be accomplished via the `svlib` make target.
-Note that each CV_CORE has a separate SVLIB directory.  Refer to `mk/Common.mk` for more details on the actual compilation and creation of the
-shared library and the variables provided to customize.
+SVLIB is partially implemented in C accessed via the SystemVerilog DPI.
+If necessary, the Makefiles will compile a shared object for you.
+You can recompile the SVLIB DPI via the `svlib` make target.
+Refer to `mk/Common.mk` for more details on the actual compilation and creation of the shared library and the variables provided to customize.
 
 
 ```
-% make svlib CV_CORE=cv32e20
+$ make svlib
 ```


### PR DESCRIPTION
This PR resolve issue #7:
- `vendor_lib/verilab/svlib_dpi.so` is not kept in the repo.
- `make svlib` will clone SVLIB and compile it into a shared object.
- `make test ...` will invoke `make svlib` if it needs to.
- `make clean_all` will delete anything cloned/built in ``vendor_lib/verilab`.

I also took the opportunity to clean up a few other items.

Note: this pull-request is from `openhwgroup/cv32e20-dv/dev_pr7` to `openhwgroup/cv32e20/dev`.   That was my mistake.  It _should_ be from `MikeOpenHWGroup/cv32e20-dv/dev_pr7` to `openhwgroup/cv32e20/dev`.  I'll get it right next time. :stuck_out_tongue_winking_eye: 
