### PR TITLE
Macros for generic warning, error and fatal messaging.

### DIFF
--- a/tb/uvmt/uvmt_cv32e20_uvm_macros_inc.sv
+++ b/tb/uvmt/uvmt_cv32e20_uvm_macros_inc.sv
@@ -2,6 +2,7 @@
 //
 // Copyright 2020,2022 OpenHW Group
 // Copyright 2020 Silicon Labs, Inc.
+// Copyright 2025 Thales DIS France SAS
 // 
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,8 +15,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
-
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+//
 
 `ifndef __UVMT_CV32E20_UVM_MACROS_INC_SV__
 `define __UVMT_CV32E20_UVM_MACROS_INC_SV__
@@ -25,7 +27,27 @@
 // include the macros definition file.
 // use of this include file "first" in the simulator compilation filelist
 // ensures all macros are properly defined for usage
-
 `include "uvm_macros.svh"
 
-`endif 
+`define ASSERT_WARNING(msg)\
+    `ifdef UVM\
+        uvm_pkg::uvm_report_warning("ASSERT FAILED", msg, uvm_pkg::UVM_NONE, 1)\
+    `else\
+        $warning("%0t: ASSERT FAILED %0s", $time, msg)\
+    `endif
+
+`define ASSERT_ERROR(msg)\
+    `ifdef UVM\
+        uvm_pkg::uvm_report_error("ASSERT FAILED", msg, uvm_pkg::UVM_NONE, 1)\
+    `else\
+        $error("%0t: ASSERT FAILED %0s", $time, msg)\
+    `endif
+
+`define ASSERT_FATAL(msg)\
+    `ifdef UVM\
+        uvm_pkg::uvm_report_fatal("ASSERT FAILED", msg, uvm_pkg::UVM_NONE, 1)\
+    `else\
+        $fatal("%0t: ASSERT FAILED %0s", $time, msg)\
+    `endif
+
+`endif // __UVMT_CV32E20_UVM_MACROS_INC_SV__


### PR DESCRIPTION
In a UVM environment these macros will invoke uvm_warning(), uvm_error() or uvm_fatal().  In non-UVM environments, $warning(), $error() or $fatal() is called.

Typical use case is for the else-clause of immediate assertions.