### PR TITLE
Enable RVFI Agent monitor's AP by default

### DIFF
--- a/mk/uvmt/dsim.mk
+++ b/mk/uvmt/dsim.mk
@@ -211,7 +211,7 @@ test: $(DSIM_SIM_PREREQ) hex gen_ovpsim_ic
 			-sv_lib $(abspath $(SVLIB_LIB)) \
 			-sv_lib $(OVP_MODEL_DPI) \
 			-sv_lib $(RVVI_STUB_LIB) \
-			+UVM_TESTNAME=$(TEST_UVM_TEST) \
+			+UVM_TESTNAME=$(UVM_TEST_NAME) \
 			+firmware=$(SIM_TEST_PROGRAM_RESULTS)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).hex \
 			+elf_file=$(SIM_TEST_PROGRAM_RESULTS)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).elf \
 			+itb_file=$(SIM_TEST_PROGRAM_RESULTS)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).itb

--- a/mk/uvmt/uvmt.mk
+++ b/mk/uvmt/uvmt.mk
@@ -168,7 +168,8 @@ DV_UVMT_SRCS                  = $(wildcard $(DV_UVMT_PATH)/*.sv))
 
 # Testcase name: must be the CLASS name of the testcase (not the filename).
 # Look in ../../tests/uvmt
-UVM_TESTNAME ?= uvmt_$(CV_CORE_LC)_firmware_test_c
+UVM_TEST_NAME ?= uvmt_$(CV_CORE_LC)_general_purpose_test_c
+TEST_UVM_TEST ?= $(UVM_TEST_NAME)
 
 # Google's random instruction generator
 RISCVDV_PKG         := $(CORE_V_VERIF)/$(CV_CORE_LC)/vendor_lib/google/riscv-dv

--- a/tb/uvmt/uvmt_cv32e20.flist
+++ b/tb/uvmt/uvmt_cv32e20.flist
@@ -44,7 +44,7 @@
 +incdir+${DV_UVMT_PATH}
 +incdir+${DV_UVMT_PATH}/../../tests/uvmt
 +incdir+${DV_UVMT_PATH}/../../tests/uvmt/base-tests
-+incdir+${DV_UVMT_PATH}/../../tests/uvmt/compliance-tests
++incdir+${DV_UVMT_PATH}/../../tests/uvmt/firmware-tests
 +incdir+${DV_UVMT_PATH}/../../tests/uvmt/vseq
 
 // CV32E20 tests (includes constants/macros/types meant for test bench)

--- a/tb/uvmt/uvmt_cv32e20_pkg.sv
+++ b/tb/uvmt/uvmt_cv32e20_pkg.sv
@@ -58,7 +58,7 @@ package uvmt_cv32e20_pkg;
    //`include "uvmt_cv32e20_smoke_test.sv" // smoke test has multile XMRs that are illegal according to the LRM
 
    // Compilance tests
-   `include "uvmt_cv32e20_firmware_test.sv"
+   `include "uvmt_cv32e20_general_purpose_test.sv"
 
 endpackage : uvmt_cv32e20_pkg
 

--- a/tb/uvmt/uvmt_cv32e20_tdefs.sv
+++ b/tb/uvmt/uvmt_cv32e20_tdefs.sv
@@ -27,6 +27,7 @@ typedef enum {
               PREEXISTING_NOTSELFCHECKING,
               GENERATED_SELFCHECKING,
               GENERATED_NOTSELFCHECKING,
+	      GENERAL_PURPOSE,
               NO_TEST_PROGRAM
              } test_program_type;
 

--- a/tests/uvmt/compliance-tests/README.md
+++ b/tests/uvmt/compliance-tests/README.md
@@ -1,2 +1,0 @@
-# Running compliance tests in the UVM environment
-Testcase `uvmt_cv32_firmware_test.sv` is implemented to run the RISC-V and OpenHW Compliance testcases.

--- a/tests/uvmt/firmware-tests/README.md
+++ b/tests/uvmt/firmware-tests/README.md
@@ -1,0 +1,9 @@
+# UVM Tests for the CV32E20 UVM environment
+In a UVM environment, all tests extend from `uvm_test`.
+In CORE-V-VERIF environments, the DUT is a processor core and much of the "stimulus" comes from test-programs running on the core,
+independant of the UVM environment.
+The implication here is that there are many test-programs and few UVM tests.
+
+- `uvmt_cv32_general_purpose_test.sv` is expected to be able to support almost all test-programs.
+
+Additional UVM tests will be added as needed.

--- a/tests/uvmt/firmware-tests/uvmt_cv32e20_general_purpose_test.sv
+++ b/tests/uvmt/firmware-tests/uvmt_cv32e20_general_purpose_test.sv
@@ -19,27 +19,27 @@
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 
 
-`ifndef __UVMT_CV32E20_FIRMWARE_TEST_SV__
-`define __UVMT_CV32E20_FIRMWARE_TEST_SV__
+`ifndef __UVMT_CV32E20_GENERAL_PURPOSE_TEST_SV__
+`define __UVMT_CV32E20_GENERAL_PURPOSE_TEST_SV__
 
 
 /**
- *  CV32E20 "firmware" test.
+ *  CV32E20 "general purpose firmware" test.
  *  This class relies on a pre-existing "firmware" file written in C and/or RISC-V assembly code.
- *
+ *  The "firmware" can be either manually written or machine generated.
  */
-class uvmt_cv32e20_firmware_test_c extends uvmt_cv32e20_base_test_c;
+class uvmt_cv32e20_general_purpose_test_c extends uvmt_cv32e20_base_test_c;
 
    constraint test_type_cons {
-     test_cfg.tpt == PREEXISTING_SELFCHECKING;
+     test_cfg.tpt == GENERAL_PURPOSE;
    }
 
-   `uvm_component_utils_begin(uvmt_cv32e20_firmware_test_c)
+   `uvm_component_utils_begin(uvmt_cv32e20_general_purpose_test_c)
    `uvm_object_utils_end
 
    /**
     */
-   extern function new(string name="uvmt_cv32e20_firmware_test", uvm_component parent=null);
+   extern function new(string name="uvmt_cv32e20_general_purpose_test", uvm_component parent=null);
 
 
    /*
@@ -70,20 +70,25 @@ class uvmt_cv32e20_firmware_test_c extends uvmt_cv32e20_base_test_c;
     */
    extern virtual task random_fetch_toggle();
 
-endclass : uvmt_cv32e20_firmware_test_c
+endclass : uvmt_cv32e20_general_purpose_test_c
 
 
-function uvmt_cv32e20_firmware_test_c::new(string name="uvmt_cv32e20_firmware_test", uvm_component parent=null);
+function uvmt_cv32e20_general_purpose_test_c::new(string name="uvmt_cv32e20_general_purpose_test", uvm_component parent=null);
 
    super.new(name, parent);
-   `uvm_info("TEST", "This is the FIRMWARE TEST", UVM_NONE)
+   `uvm_info("TEST", "This is the GENERAL PURPOSE FIRMWARE UVM_TEST", UVM_NONE)
 
 endfunction : new
 
-task uvmt_cv32e20_firmware_test_c::run_phase(uvm_phase phase);
+task uvmt_cv32e20_general_purpose_test_c::run_phase(uvm_phase phase);
 
    // start_clk() and watchdog_timer() are called in the base_test
    super.run_phase(phase);
+
+   // The RVFI Agent needs to be writting to it AP, otherwise the reference
+   // model and ISA functional coverage model have nothing to proces.
+   env.rvfi_agent.instr_monitor.cfg.ap_write_en = 1;
+   `uvm_info("TEST", "Writing to RVFI Agent's instruction monitor Analysis Port enabled", UVM_NONE)
 
    if ($test$plusargs("gen_random_debug")) begin
     fork
@@ -137,7 +142,7 @@ task uvmt_cv32e20_firmware_test_c::run_phase(uvm_phase phase);
 
 endtask : run_phase
 
-task uvmt_cv32e20_firmware_test_c::reset_debug();
+task uvmt_cv32e20_general_purpose_test_c::reset_debug();
     uvme_cv32e20_random_debug_reset_c debug_vseq;
     debug_vseq = uvme_cv32e20_random_debug_reset_c::type_id::create("random_debug_reset_vseqr", vsequencer);
     `uvm_info("TEST", "Applying debug_req_i at reset", UVM_NONE);
@@ -150,15 +155,15 @@ task uvmt_cv32e20_firmware_test_c::reset_debug();
 
 endtask
 
-function void uvmt_cv32e20_firmware_test_c::build_phase(uvm_phase phase);
+function void uvmt_cv32e20_general_purpose_test_c::build_phase(uvm_phase phase);
        super.build_phase(phase);
 
-       `uvm_info("firmware_test", "Overriding Reference Model with Spike", UVM_NONE)
+       `uvm_info("TEST", "Overriding Reference Model with Spike", UVM_NONE)
        set_type_override_by_type(uvmc_rvfi_reference_model#()::get_type(),uvmc_rvfi_spike#()::get_type());
 
 endfunction : build_phase
 
-task uvmt_cv32e20_firmware_test_c::bootset_debug();
+task uvmt_cv32e20_general_purpose_test_c::bootset_debug();
     uvme_cv32e20_random_debug_bootset_c debug_vseq;
     debug_vseq = uvme_cv32e20_random_debug_bootset_c::type_id::create("random_debug_bootset_vseqr", vsequencer);
     `uvm_info("TEST", "Applying single cycle debug_req after reset", UVM_NONE);
@@ -177,7 +182,7 @@ task uvmt_cv32e20_firmware_test_c::bootset_debug();
 
 endtask
 
-task uvmt_cv32e20_firmware_test_c::random_debug();
+task uvmt_cv32e20_general_purpose_test_c::random_debug();
     `uvm_info("TEST", "Starting random debug in thread UVM test", UVM_NONE)
 
     while (1) begin
@@ -192,7 +197,7 @@ task uvmt_cv32e20_firmware_test_c::random_debug();
     end
 endtask : random_debug
 
-task uvmt_cv32e20_firmware_test_c::irq_noise();
+task uvmt_cv32e20_general_purpose_test_c::irq_noise();
   `uvm_info("TEST", "Starting IRQ Noise thread in UVM test", UVM_NONE);
   while (1) begin
     uvme_cv32e20_interrupt_noise_c interrupt_noise_vseq;
@@ -206,7 +211,7 @@ task uvmt_cv32e20_firmware_test_c::irq_noise();
   end
 endtask : irq_noise
 
-task uvmt_cv32e20_firmware_test_c::random_fetch_toggle();
+task uvmt_cv32e20_general_purpose_test_c::random_fetch_toggle();
   `uvm_info("TEST", "Starting random_fetch_toggle thread in UVM test", UVM_NONE);
   while (1) begin
     int unsigned fetch_assert_cycles;
@@ -236,4 +241,4 @@ task uvmt_cv32e20_firmware_test_c::random_fetch_toggle();
 
 endtask : random_fetch_toggle
 
-`endif // __UVMT_CV32E20_FIRMWARE_TEST_SV__
+`endif // __UVMT_CV32E20_GENERAL_PURPOSE_TEST_SV__


### PR DESCRIPTION
This PR solves the issue discussed in [MikeOpenHWGroup/cv32e20-dv pull-request #2](https://github.com/MikeOpenHWGroup/cv32e20-dv/pull/2) in which the AP had to be enabled by manually hacking `vendor_lib/openhwgroup_core-v-verif/lib/uvm_agents/uvma_rvfi/uvma_rvfi_cfg.sv`.  It also attempts to clean up a few minor issues related to the UVM test that runs most simulations in this environment.