### PR TITLE
bin/objdump2itb: Fix Python 3.12 SyntaxWarnings (invalid escape sequences)

### DIFF
--- a/bin/objdump2itb
+++ b/bin/objdump2itb
@@ -74,19 +74,19 @@ class CFunction:
 # Regular expression to extract a function from objdump
 # Example:
 # 00000256 <end_handler_incr_mepc>:
-FUNC_PATTERN     = "(?P<addr>[0-9a-f]{8}) <(?P<name>\S*)>:"
+FUNC_PATTERN     = r"(?P<addr>[0-9a-f]{8}) <(?P<name>\S*)>:"
 FUNC_RE          = re.compile(FUNC_PATTERN)
 
 # Regular expression to extract an individual instruction
 # Example:
 #      264:       00a31363                bne     t1,a0,26a <end_handler_incr_mepc2>
-INST_PATTERN     = "(?P<addr>[0-9a-f]{1,8}):\t*(?P<mcode>[0-9a-f]{4}([0-9a-f]{4})?)\s{2,}(?P<asm>[a-z].*)$"
+INST_PATTERN     = r"(?P<addr>[0-9a-f]{1,8}):\t*(?P<mcode>[0-9a-f]{4}([0-9a-f]{4})?)\s{2,}(?P<asm>[a-z].*)$"
 INST_RE          = re.compile(INST_PATTERN)
 
 # Regular expression to extract a source annotation for each instruction
 # Example:
 # /work/strichmo/core-v-verif/cv32e40x/tests/programs/custom/debug_test_trigger/debugger.S:47
-SRC_FILE_PATTERN = "^(?P<dir>/\S+)/(?P<file>[^/\s]+):(?P<line>[0-9]*)$" 
+SRC_FILE_PATTERN = r"^(?P<dir>/\S+)/(?P<file>[^/\s]+):(?P<line>[0-9]*)$" 
 SRC_FILE_RE      = re.compile(SRC_FILE_PATTERN)
 
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)


### PR DESCRIPTION
## Description

This PR fixes multiple `SyntaxWarning: invalid escape sequence` messages in the bin/objdump2itb script when running on Python 3.12 (e.g., Ubuntu 24.04). 

The issue stems from the use of backslashes in non-raw strings within regular expressions. According to Python 3.12 release notes, invalid escape sequences in string literals now trigger a `SyntaxWarning` and will eventually become a `SyntaxError`.

### Changes Implemented
- Converted the following regex patterns in bin/objdump2itb to **raw strings** by adding the `r` prefix:
    - `FUNC_PATTERN`
    - `INST_PATTERN`
    - `SRC_FILE_PATTERN`

This ensures that the backslashes (e.g., `\S`, `\s`, `\t`) are treated as literal characters for the regex engine rather than interpreted as escape sequences by Python.

### Verification Performed
- **Warning Suppression**: Verified that running the script with `python3 -W error bin/objdump2itb --help` (which turns warnings into errors) now completes successfully without warnings.
- **Output Integrity**: Verified that the patched script produces bit-for-bit identical `.itb` files compared to the original version.