### PR TITLE
bin/objdump2itb: Fix crash on pre-label instructions

### DIFF
--- a/bin/objdump2itb
+++ b/bin/objdump2itb
@@ -110,7 +110,7 @@ def parse(objdump):
     else:
         fp = open(objdump)
 
-    current_cfunction = None
+    current_cfunction = CFunction(0, "<unknown>")
     current_src_file = None
     current_src_line = 0
     current_src_code = ""    


### PR DESCRIPTION
## Description

This PR fixes an `AttributeError: 'NoneType' object has no attribute 'name'` in `bin/objdump2itb` that occurs when parsing an `objdump` file where instructions appear before the first function label.

Previously, `current_cfunction` was initialized to `None`, causing a crash when accessing `current_cfunction.name` for pre-label instructions. This change initializes it to a default `CFunction(0, "<unknown>")` to handle these cases gracefully and improve robustness.

---

## Change

```python
current_cfunction = CFunction(0, "<unknown>")
```

---

## Steps to Reproduce

1. Create a `test.objdump` file containing instructions before any function label:

```
0:  00000013           nop
00000004 <_start>:
   4:  00000013           nop
```

2. Run:

```
python3 bin/objdump2itb test.objdump
```

---

## Behavior

**Before fix:**

```
AttributeError: 'NoneType' object has no attribute 'name'
```

**After fix:**

The script parses successfully without crashing.

---

Fixes issue mentioned in #20 .
