### PR TITLE
raise BOOT_ADDR from 0x2000 to 0x4000

### DIFF
--- a/tb/core/tb_top.sv
+++ b/tb/core/tb_top.sv
@@ -22,7 +22,7 @@
 module tb_top
     #(parameter INSTR_RDATA_WIDTH = 32,
       parameter RAM_ADDR_WIDTH    = 22,
-      parameter BOOT_ADDR         = 'h2000 // must be 256-byte aligned (cannot be 'h80)
+      parameter BOOT_ADDR         = 'h4000 // must be 256-byte aligned; raised from 'h2000 to satisfy .align 14 in I-jal test
      );
 
     const int CLK_PHASE_HI        = 5;


### PR DESCRIPTION
I-jal generated test from ACT4 uses .align 14, requiring .text at a 16KB-aligned address. Therefore 0x2000 value in boot address is wrong and needs to be moved to 0x4000 for tests to correctly execute all JAL instruction in generated tests.

Sail doesn't use a hardcoded reset vector - it loads the ELF and starts executing from the rvtest_entry_point symbol directly, wherever the linker placed it. So Sail was always running from 0x4000 (following the ELF), while the DUT was reset-fetching from 0x2000, a completely different address. That is why Sail produced a correct signature while the DUT hung.
