### PR TITLE
Run all tests branch

### DIFF
--- a/sim/ExternalRepos.mk
+++ b/sim/ExternalRepos.mk
@@ -39,5 +39,5 @@ SVLIB_HASH       ?= c25509a7e54a880fe8f58f3daa2f891d6ecf6428
 
 # ACT4 (RISC-V Architectural Certification Tests)
 ACT4_REPO   ?= https://github.com/karabambus/riscv-arch-test
-ACT4_BRANCH ?= fix/cv32e20-misaligned-sail-config
-ACT4_HASH   ?= 124b4a7ef9db4af2b38d76c5a1a49e849dca64b7
+ACT4_BRANCH ?= fix/cv32e20-sail-schema-v0.11
+ACT4_HASH   ?= head

--- a/sim/ExternalRepos.mk
+++ b/sim/ExternalRepos.mk
@@ -40,4 +40,4 @@ SVLIB_HASH       ?= c25509a7e54a880fe8f58f3daa2f891d6ecf6428
 # ACT4 (RISC-V Architectural Certification Tests)
 ACT4_REPO   ?= https://github.com/riscv-non-isa/riscv-arch-test
 ACT4_BRANCH ?= act4
-ACT4_HASH   ?= 3b087b34750a63522dadb7fbec857bbe9d8e2a70
+ACT4_HASH   ?= 362b819b97087e96dbe4a04cce70c1515c21472b

--- a/sim/ExternalRepos.mk
+++ b/sim/ExternalRepos.mk
@@ -38,6 +38,6 @@ SVLIB_BRANCH     ?= master
 SVLIB_HASH       ?= c25509a7e54a880fe8f58f3daa2f891d6ecf6428
 
 # ACT4 (RISC-V Architectural Certification Tests)
-ACT4_REPO   ?= https://github.com/riscv-non-isa/riscv-arch-test
-ACT4_BRANCH ?= act4
-ACT4_HASH   ?= 362b819b97087e96dbe4a04cce70c1515c21472b
+ACT4_REPO   ?= https://github.com/karabambus/riscv-arch-test
+ACT4_BRANCH ?= fix/cv32e20-misaligned-sail-config
+ACT4_HASH   ?= 124b4a7ef9db4af2b38d76c5a1a49e849dca64b7

--- a/sim/core/Makefile
+++ b/sim/core/Makefile
@@ -312,18 +312,20 @@ certify: verilate
 	SUMMARY="$(VERI_LOG_DIR)/certification_summary.txt"; \
 	echo "RESULT  TEST" > "$$SUMMARY"; \
 	echo "------  ----" >> "$$SUMMARY"; \
-	ROOT="$(certification_PROGRAM_PATH)/rv32i$(if $(FILTER),/$(FILTER),)"; \
-	ELFS="$$(find -L "$$ROOT" \( -type f -o -type l \) -a \( -iname '*.elf' -o -iname '*.elf32' \) 2>/dev/null | sort)"; \
+	UNPRIV_ROOT="$(certification_PROGRAM_PATH)/rv32i$(if $(FILTER),/$(FILTER),)"; \
+	PRIV_ROOT="$(certification_PROGRAM_PATH)/priv$(if $(FILTER),/$(FILTER),)"; \
+	ELFS="$$(find -L "$$UNPRIV_ROOT" "$$PRIV_ROOT" \( -type f -o -type l \) -a \( -iname '*.elf' -o -iname '*.elf32' \) 2>/dev/null | sort)"; \
 	if [ -z "$$ELFS" ]; then \
-	  echo "No .elf files found under $$ROOT"; \
+	  echo "No .elf files found under $$UNPRIV_ROOT or $$PRIV_ROOT"; \
 	  echo "Debug listing (2 levels):"; \
-	  find "$$ROOT" -maxdepth 2 -print || true; \
+	  find "$$UNPRIV_ROOT" "$$PRIV_ROOT" -maxdepth 2 -print || true; \
 	  exit 2; \
 	fi; \
+	ELF_BASE="$(certification_PROGRAM_PATH)"; \
 	PASS=0; FAIL=0; TOTAL=0; \
 	for ELF in $$ELFS; do \
 	  TOTAL=$$((TOTAL+1)); \
-	  REL="$${ELF#$$ROOT/}"; \
+	  REL="$${ELF#$$ELF_BASE/}"; \
 	  BASE="$${ELF%.*}"; \
 	  HEX="$$BASE.hex"; \
 	  LOG="$(VERI_LOG_DIR)/$${REL%.*}.log"; \

--- a/sim/core/Makefile
+++ b/sim/core/Makefile
@@ -297,7 +297,7 @@ gen: $(ACT4_PKG)
 	@$(MAKE) -C $(ACT4_PKG) clean
 	@echo "* Generating ACT4.0 tests..."
 	@$(MAKE) -C $(ACT4_PKG) \
-		EXCLUDE_EXTENSIONS=ExceptionsSm,InterruptsSm,ExceptionsZc,Sm \
+		EXCLUDE_EXTENSIONS=S,Sm,InterruptsSm,ExceptionsZalrsc,ExceptionsZaamo,PMPSm,PMPZca,PMPmisaligned,Sv,Svade,Svadu,SvaduPMP,SvPMP,SvZicbo,SvPMPZicbo \
 		CONFIG_FILES=config/cores/cve2/cv32e20/test_config.yaml
 	@echo "* Tests generated in: $(certification_PROGRAM_PATH)"
 

--- a/sim/core/Makefile
+++ b/sim/core/Makefile
@@ -297,7 +297,7 @@ gen: $(ACT4_PKG)
 	@$(MAKE) -C $(ACT4_PKG) clean
 	@echo "* Generating ACT4.0 tests..."
 	@$(MAKE) -C $(ACT4_PKG) \
-		EXTENSIONS=I,M,C,Zca,Zicsr,Zifencei \
+		EXCLUDE_EXTENSIONS=ExceptionsSm,InterruptsSm,ExceptionsZc,Sm \
 		CONFIG_FILES=config/cores/cve2/cv32e20/test_config.yaml
 	@echo "* Tests generated in: $(certification_PROGRAM_PATH)"
 


### PR DESCRIPTION
## Description
This PR integrates all ACT4 tests applicable to CV32E20 (RV32IMC, machine mode). It uses the ACT4 upstream default exclusion list so privileged exception tests (ExceptionsSm, ExceptionsZc) are now built and run alongside the unprivileged suite.

## Changes
- `sim/ExternalRepos.mk`: point to `fix/cv32e20-sail-schema-v0.11` — updates `sail.json` to the sail-riscv 0.11 schema
- `sim/core/Makefile`: use ACT4 default `EXCLUDE_EXTENSIONS` (keeps `Sm`, `InterruptsSm` excluded; enables `ExceptionsSm`, `ExceptionsZc`)
- `sim/core/Makefile`: certify now scans both `priv/` and `rv32i/` ELF directories

## Test results — TOTAL=91 PASS=91 FAIL=0

### Privileged

| Test | Result |
|------|--------|
| priv/ExceptionsSm/ExceptionsSm-00.elf | PASS |
| priv/ExceptionsZc/ExceptionsZc-00.elf | PASS |

### Unprivileged — I (41 tests)

<details>
<summary>Show all I tests</summary>

```
PASS    rv32i/I/I-add-00.elf
PASS    rv32i/I/I-addi-00.elf
PASS    rv32i/I/I-and-00.elf
PASS    rv32i/I/I-andi-00.elf
PASS    rv32i/I/I-auipc-00.elf
PASS    rv32i/I/I-beq-00.elf
PASS    rv32i/I/I-bge-00.elf
PASS    rv32i/I/I-bgeu-00.elf
PASS    rv32i/I/I-blt-00.elf
PASS    rv32i/I/I-bltu-00.elf
PASS    rv32i/I/I-bne-00.elf
PASS    rv32i/I/I-fence-00.elf
PASS    rv32i/I/I-jal-00.elf
PASS    rv32i/I/I-jalr-00.elf
PASS    rv32i/I/I-lb-00.elf
PASS    rv32i/I/I-lbu-00.elf
PASS    rv32i/I/I-lh-00.elf
PASS    rv32i/I/I-lhu-00.elf
PASS    rv32i/I/I-lui-00.elf
PASS    rv32i/I/I-lw-00.elf
PASS    rv32i/I/I-nop-00.elf
PASS    rv32i/I/I-or-00.elf
PASS    rv32i/I/I-ori-00.elf
PASS    rv32i/I/I-sb-00.elf
PASS    rv32i/I/I-sh-00.elf
PASS    rv32i/I/I-sll-00.elf
PASS    rv32i/I/I-slli-00.elf
PASS    rv32i/I/I-slt-00.elf
PASS    rv32i/I/I-slti-00.elf
PASS    rv32i/I/I-sltiu-00.elf
PASS    rv32i/I/I-sltu-00.elf
PASS    rv32i/I/I-sra-00.elf
PASS    rv32i/I/I-srai-00.elf
PASS    rv32i/I/I-srl-00.elf
PASS    rv32i/I/I-srli-00.elf
PASS    rv32i/I/I-sub-00.elf
PASS    rv32i/I/I-sw-00.elf
PASS    rv32i/I/I-xor-00.elf
PASS    rv32i/I/I-xori-00.elf
```
</details>

### Unprivileged — M (8 tests)

```
PASS    rv32i/M/M-div-00.elf
PASS    rv32i/M/M-divu-00.elf
PASS    rv32i/M/M-mul-00.elf
PASS    rv32i/M/M-mulh-00.elf
PASS    rv32i/M/M-mulhsu-00.elf
PASS    rv32i/M/M-mulhu-00.elf
PASS    rv32i/M/M-rem-00.elf
PASS    rv32i/M/M-remu-00.elf
```

### Unprivileged — Zca (27 tests)

<details>
<summary>Show all Zca tests</summary>

```
PASS    rv32i/Zca/Zca-c.add-00.elf
PASS    rv32i/Zca/Zca-c.addi-00.elf
PASS    rv32i/Zca/Zca-c.addi16sp-00.elf
PASS    rv32i/Zca/Zca-c.addi4spn-00.elf
PASS    rv32i/Zca/Zca-c.and-00.elf
PASS    rv32i/Zca/Zca-c.andi-00.elf
PASS    rv32i/Zca/Zca-c.beqz-00.elf
PASS    rv32i/Zca/Zca-c.bnez-00.elf
PASS    rv32i/Zca/Zca-c.j-00.elf
PASS    rv32i/Zca/Zca-c.jal-00.elf
PASS    rv32i/Zca/Zca-c.jalr-00.elf
PASS    rv32i/Zca/Zca-c.jr-00.elf
PASS    rv32i/Zca/Zca-c.li-00.elf
PASS    rv32i/Zca/Zca-c.lui-00.elf
PASS    rv32i/Zca/Zca-c.lw-00.elf
PASS    rv32i/Zca/Zca-c.lwsp-00.elf
PASS    rv32i/Zca/Zca-c.mv-00.elf
PASS    rv32i/Zca/Zca-c.nop-00.elf
PASS    rv32i/Zca/Zca-c.or-00.elf
PASS    rv32i/Zca/Zca-c.slli-00.elf
PASS    rv32i/Zca/Zca-c.srai-00.elf
PASS    rv32i/Zca/Zca-c.srli-00.elf
PASS    rv32i/Zca/Zca-c.sub-00.elf
PASS    rv32i/Zca/Zca-c.sw-00.elf
PASS    rv32i/Zca/Zca-c.swsp-00.elf
PASS    rv32i/Zca/Zca-c.xor-00.elf
```
</details>

### Unprivileged — Zicsr (6 tests)

```
PASS    rv32i/Zicsr/Zicsr-csrrc-00.elf
PASS    rv32i/Zicsr/Zicsr-csrrci-00.elf
PASS    rv32i/Zicsr/Zicsr-csrrs-00.elf
PASS    rv32i/Zicsr/Zicsr-csrrsi-00.elf
PASS    rv32i/Zicsr/Zicsr-csrrw-00.elf
PASS    rv32i/Zicsr/Zicsr-csrrwi-00.elf
```

### Unprivileged — Zifencei, Misalign, MisalignZca (10 tests)

```
PASS    rv32i/Zifencei/Zifencei-fence.i-00.elf
PASS    rv32i/Misalign/Misalign-lh-00.elf
PASS    rv32i/Misalign/Misalign-lhu-00.elf
PASS    rv32i/Misalign/Misalign-lw-00.elf
PASS    rv32i/Misalign/Misalign-sh-00.elf
PASS    rv32i/Misalign/Misalign-sw-00.elf
PASS    rv32i/MisalignZca/MisalignZca-c.lw-00.elf
PASS    rv32i/MisalignZca/MisalignZca-c.lwsp-00.elf
PASS    rv32i/MisalignZca/MisalignZca-c.sw-00.elf
PASS    rv32i/MisalignZca/MisalignZca-c.swsp-00.elf
```

## Still excluded

See #46 for details on remaining excluded test suites (Sm, InterruptsSm).