### PR TITLE
sim: update ACT4 to upstream head after riscv-arch-test#1277 merges

### DIFF
--- a/sim/ExternalRepos.mk
+++ b/sim/ExternalRepos.mk
@@ -40,4 +40,4 @@ SVLIB_HASH       ?= c25509a7e54a880fe8f58f3daa2f891d6ecf6428
 # ACT4 (RISC-V Architectural Certification Tests)
 ACT4_REPO   ?= https://github.com/riscv-non-isa/riscv-arch-test
 ACT4_BRANCH ?= act4
-ACT4_HASH   ?= 3b087b34750a63522dadb7fbec857bbe9d8e2a70
+ACT4_HASH   ?= 0a16526f47458456645cd25cdd5f79b8a28c0796


### PR DESCRIPTION
Closes openhwgroup/cv32e20-dv#48

riscv/riscv-arch-test#1277 has merged into the act4 branch. Update `ACT4_HASH` to the merge commit


