### PR TITLE
Bump act4 version to latest

### DIFF
--- a/sim/ExternalRepos.mk
+++ b/sim/ExternalRepos.mk
@@ -40,4 +40,4 @@ SVLIB_HASH       ?= c25509a7e54a880fe8f58f3daa2f891d6ecf6428
 # ACT4 (RISC-V Architectural Certification Tests)
 ACT4_REPO   ?= https://github.com/riscv-non-isa/riscv-arch-test
 ACT4_BRANCH ?= act4
-ACT4_HASH   ?= 3b087b34750a63522dadb7fbec857bbe9d8e2a70
+ACT4_HASH   ?= 362b819b97087e96dbe4a04cce70c1515c21472b

--- a/sim/ExternalRepos.mk
+++ b/sim/ExternalRepos.mk
@@ -38,7 +38,7 @@ SVLIB_BRANCH     ?= master
 SVLIB_HASH       ?= c25509a7e54a880fe8f58f3daa2f891d6ecf6428
 
 # ACT4 (RISC-V Architectural Certification Tests)
-ACT4_REPO   ?= https://github.com/riscv-non-isa/riscv-arch-test
+ACT4_REPO   ?= https://github.com/riscv/riscv-arch-test
 ACT4_BRANCH ?= act4
-ACT4_HASH   ?= cf347755f910a6f717b73665823de0c98dd6b53e
+ACT4_HASH   ?= head
 

--- a/sim/ExternalRepos.mk
+++ b/sim/ExternalRepos.mk
@@ -40,4 +40,5 @@ SVLIB_HASH       ?= c25509a7e54a880fe8f58f3daa2f891d6ecf6428
 # ACT4 (RISC-V Architectural Certification Tests)
 ACT4_REPO   ?= https://github.com/riscv-non-isa/riscv-arch-test
 ACT4_BRANCH ?= act4
-ACT4_HASH   ?= 362b819b97087e96dbe4a04cce70c1515c21472b
+ACT4_HASH   ?= cf347755f910a6f717b73665823de0c98dd6b53e
+

--- a/sim/core/Makefile
+++ b/sim/core/Makefile
@@ -297,7 +297,7 @@ gen: $(ACT4_PKG)
 	@$(MAKE) -C $(ACT4_PKG) clean
 	@echo "* Generating ACT4.0 tests..."
 	@$(MAKE) -C $(ACT4_PKG) \
-		EXTENSIONS=I,M,C,Zca,Zicsr,Zifencei \
+		EXTENSIONS= \
 		CONFIG_FILES=config/cores/cve2/cv32e20/test_config.yaml
 	@echo "* Tests generated in: $(certification_PROGRAM_PATH)"
 
@@ -312,7 +312,7 @@ certify: verilate
 	SUMMARY="$(VERI_LOG_DIR)/certification_summary.txt"; \
 	echo "RESULT  TEST" > "$$SUMMARY"; \
 	echo "------  ----" >> "$$SUMMARY"; \
-	ROOT="$(certification_PROGRAM_PATH)/rv32i$(if $(FILTER),/$(FILTER),)"; \
+	ROOT="$(certification_PROGRAM_PATH)$(if $(FILTER),/$(FILTER),)"; \
 	ELFS="$$(find -L "$$ROOT" \( -type f -o -type l \) -a \( -iname '*.elf' -o -iname '*.elf32' \) 2>/dev/null | sort)"; \
 	if [ -z "$$ELFS" ]; then \
 	  echo "No .elf files found under $$ROOT"; \

--- a/sim/core/Makefile
+++ b/sim/core/Makefile
@@ -297,7 +297,7 @@ gen: $(ACT4_PKG)
 	@$(MAKE) -C $(ACT4_PKG) clean
 	@echo "* Generating ACT4.0 tests..."
 	@$(MAKE) -C $(ACT4_PKG) \
-		EXTENSIONS= \
+		EXTENSIONS=I,M,C,Zca,Zicsr,Zifencei \
 		CONFIG_FILES=config/cores/cve2/cv32e20/test_config.yaml
 	@echo "* Tests generated in: $(certification_PROGRAM_PATH)"
 

--- a/sim/core/Makefile
+++ b/sim/core/Makefile
@@ -312,7 +312,7 @@ certify: verilate
 	SUMMARY="$(VERI_LOG_DIR)/certification_summary.txt"; \
 	echo "RESULT  TEST" > "$$SUMMARY"; \
 	echo "------  ----" >> "$$SUMMARY"; \
-	ROOT="$(certification_PROGRAM_PATH)$(if $(FILTER),/$(FILTER),)"; \
+	ROOT="$(certification_PROGRAM_PATH)/rv32i$(if $(FILTER),/$(FILTER),)"; \
 	ELFS="$$(find -L "$$ROOT" \( -type f -o -type l \) -a \( -iname '*.elf' -o -iname '*.elf32' \) 2>/dev/null | sort)"; \
 	if [ -z "$$ELFS" ]; then \
 	  echo "No .elf files found under $$ROOT"; \


### PR DESCRIPTION
## Description
Update ACT4 external repo.
## Changes
- sim/core/ExternalRepos.mk: ACT4 pinned to head 
- ACT4 requires Sail 0.11 now
## Verification
Running full gen-certify flow with fresh ACT4 repo. 
- 92/91 tests pass (this is with privileged tests). InterruptsSm is failing (ACT4 issue).

