### PR TITLE
Fix riscv_arithmetic_basic_test_0

### DIFF
--- a/tests/asm/user_define.h
+++ b/tests/asm/user_define.h
@@ -5,7 +5,8 @@
 .section .data
 .global test_results
 test_results:
-	.word 000000001
+#	.word 000000001
+	.word 000000000
 
 #TODO: figure out how to move this to the end of the program
 #.section .text

--- a/tests/programs/custom/riscv_arithmetic_basic_test_0/riscv_arithmetic_basic_test_0.S
+++ b/tests/programs/custom/riscv_arithmetic_basic_test_0/riscv_arithmetic_basic_test_0.S
@@ -2,13 +2,13 @@
 #.include "user_define.h"
 #.globl _start
 #.section .text
-#_start:
+#_start:           
 # END: riscv-dv
 # BEGIN: gtumbush
 .include "user_define.h"
-
 .section .text.start
 .globl _start
+.section .text
 .type _start, @function
 
 
@@ -18,7 +18,7 @@ _start:
 
 .globl _start_main
 .section .text
-_start_main:
+_start_main:          
 # END: gtumbush
 # BEGIN: riscv-dv
                   csrr x5, mhartid
@@ -29,20 +29,20 @@ _start_main:
 h0_start:
                   li x30, 0x40001104
                   csrw misa, x30
-kernel_sp:
+kernel_sp:        
                   la x13, kernel_stack_end
 
-trap_vec_init:
+trap_vec_init:    
                   la x30, mtvec_handler
                   ori x30, x30, 1
                   csrw 0x305, x30 # MTVEC
 
-mepc_setup:
+mepc_setup:       
                   la x30, init
                   csrw mepc, x30
                   j init_machine_mode
 
-init:
+init:             
                   li x0, 0xffae545d
                   li x1, 0xf
                   li x2, 0xfaea503e
@@ -11305,7 +11305,22 @@ fast_exit:
                   sw a5,0(a0)
                   sw a5,0(a0)
 
-                  j _test_pass
+                  li a0, test_ret_val
+                  lw a1, test_results /* report result */
+                  sw a1,0(a0)
+
+                  wfi  /* we are done */
+##End: Extracted from riscv_compliance_tests/riscv_test.h
+
+                  j test_done
+test_done:        
+                  li gp, 1
+                  ecall
+write_tohost:     
+                  sw gp, tohost, t5
+
+_exit:            
+                  j write_tohost
 
 init_machine_mode:
                   li x30, 0x1800
@@ -11313,9 +11328,13 @@ init_machine_mode:
                   li x30, 0x0
                   csrw 0x304, x30 # MIE
                   mret
-instr_end:
+instr_end:        
                   nop
 
+.section .data
+.align 6; .global tohost; tohost: .dword 0;
+.align 6; .global fromhost; fromhost: .dword 0;
+.section .user_stack,"aw",@progbits;
 .align 2
 user_stack_start:
 .rept 4999
@@ -11365,7 +11384,7 @@ mmode_intr_vector_1:
                   srli x30, x30, 0x1f
                   beqz x30, 1f
                   j mmode_intr_handler
-                  1: j _test_pass
+                  1: j test_done
 
 mmode_intr_vector_2:
                   csrrw x12, 0x340, x12
@@ -11406,7 +11425,7 @@ mmode_intr_vector_2:
                   srli x30, x30, 0x1f
                   beqz x30, 1f
                   j mmode_intr_handler
-                  1: j _test_pass
+                  1: j test_done
 
 mmode_intr_vector_3:
                   csrrw x12, 0x340, x12
@@ -11447,7 +11466,7 @@ mmode_intr_vector_3:
                   srli x30, x30, 0x1f
                   beqz x30, 1f
                   j mmode_intr_handler
-                  1: j _test_pass
+                  1: j test_done
 
 mmode_intr_vector_4:
                   csrrw x12, 0x340, x12
@@ -11488,7 +11507,7 @@ mmode_intr_vector_4:
                   srli x30, x30, 0x1f
                   beqz x30, 1f
                   j mmode_intr_handler
-                  1: j _test_pass
+                  1: j test_done
 
 mmode_intr_vector_5:
                   csrrw x12, 0x340, x12
@@ -11529,7 +11548,7 @@ mmode_intr_vector_5:
                   srli x30, x30, 0x1f
                   beqz x30, 1f
                   j mmode_intr_handler
-                  1: j _test_pass
+                  1: j test_done
 
 mmode_intr_vector_6:
                   csrrw x12, 0x340, x12
@@ -11570,7 +11589,7 @@ mmode_intr_vector_6:
                   srli x30, x30, 0x1f
                   beqz x30, 1f
                   j mmode_intr_handler
-                  1: j _test_pass
+                  1: j test_done
 
 mmode_intr_vector_7:
                   csrrw x12, 0x340, x12
@@ -11611,7 +11630,7 @@ mmode_intr_vector_7:
                   srli x30, x30, 0x1f
                   beqz x30, 1f
                   j mmode_intr_handler
-                  1: j _test_pass
+                  1: j test_done
 
 mmode_intr_vector_8:
                   csrrw x12, 0x340, x12
@@ -11652,7 +11671,7 @@ mmode_intr_vector_8:
                   srli x30, x30, 0x1f
                   beqz x30, 1f
                   j mmode_intr_handler
-                  1: j _test_pass
+                  1: j test_done
 
 mmode_intr_vector_9:
                   csrrw x12, 0x340, x12
@@ -11693,7 +11712,7 @@ mmode_intr_vector_9:
                   srli x30, x30, 0x1f
                   beqz x30, 1f
                   j mmode_intr_handler
-                  1: j _test_pass
+                  1: j test_done
 
 mmode_intr_vector_10:
                   csrrw x12, 0x340, x12
@@ -11734,7 +11753,7 @@ mmode_intr_vector_10:
                   srli x30, x30, 0x1f
                   beqz x30, 1f
                   j mmode_intr_handler
-                  1: j _test_pass
+                  1: j test_done
 
 mmode_intr_vector_11:
                   csrrw x12, 0x340, x12
@@ -11775,7 +11794,7 @@ mmode_intr_vector_11:
                   srli x30, x30, 0x1f
                   beqz x30, 1f
                   j mmode_intr_handler
-                  1: j _test_pass
+                  1: j test_done
 
 mmode_intr_vector_12:
                   csrrw x12, 0x340, x12
@@ -11816,7 +11835,7 @@ mmode_intr_vector_12:
                   srli x30, x30, 0x1f
                   beqz x30, 1f
                   j mmode_intr_handler
-                  1: j _test_pass
+                  1: j test_done
 
 mmode_intr_vector_13:
                   csrrw x12, 0x340, x12
@@ -11857,7 +11876,7 @@ mmode_intr_vector_13:
                   srli x30, x30, 0x1f
                   beqz x30, 1f
                   j mmode_intr_handler
-                  1: j _test_pass
+                  1: j test_done
 
 mmode_intr_vector_14:
                   csrrw x12, 0x340, x12
@@ -11898,7 +11917,7 @@ mmode_intr_vector_14:
                   srli x30, x30, 0x1f
                   beqz x30, 1f
                   j mmode_intr_handler
-                  1: j _test_pass
+                  1: j test_done
 
 mmode_intr_vector_15:
                   csrrw x12, 0x340, x12
@@ -11939,10 +11958,10 @@ mmode_intr_vector_15:
                   srli x30, x30, 0x1f
                   beqz x30, 1f
                   j mmode_intr_handler
-                  1: j _test_pass
+                  1: j test_done
 
-.align 8
-mtvec_handler:
+.align 2
+mtvec_handler:    
                   .option norvc;
                   j mmode_exception_handler
                   j mmode_intr_vector_1
@@ -12022,9 +12041,9 @@ mmode_exception_handler:
                   li x22, 0x2 # ILLEGAL_INSTRUCTION
                   beq x30, x22, illegal_instr_handler
                   csrr x22, 0x343 # MTVAL
-                  1: jal x1, _test_pass
+                  1: jal x1, test_done 
 
-ecall_handler:
+ecall_handler:    
                   la x30, _start
                   sw x0, 0(x30)
                   sw x1, 4(x30)
@@ -12058,7 +12077,7 @@ ecall_handler:
                   sw x29, 116(x30)
                   sw x30, 120(x30)
                   sw x31, 124(x30)
-                  j _exit
+                  j write_tohost
 instr_fault_handler:
                   lw  x1, 4(x12)
                   lw  x2, 8(x12)
@@ -12170,7 +12189,7 @@ store_fault_handler:
                   csrrw x12, 0x340, x12
                   mret
 
-ebreak_handler:
+ebreak_handler:   
                   csrr  x30, mepc
                   addi  x30, x30, 4
                   csrw  mepc, x30
@@ -12250,7 +12269,7 @@ illegal_instr_handler:
                   csrrw x12, 0x340, x12
                   mret
 
-pt_fault_handler:
+pt_fault_handler: 
                   nop
 
 .align 2


### PR DESCRIPTION
Hi @cairo-caplan, this PR fixes the "hanging test" issue you reported this week.  I am not sure how, but the assembly test-programs for the e20 are not right.  This will get you going, but I am going to continue to investigate. 

This PR changes two files:

1. **tests/asm/user_define.h**: the value of the `test_results` symbol was set to 0x1.  The test-program writes this value to the [Virtual Peripheral Status Flags](https://docs.openhwgroup.org/projects/core-v-verif/en/latest/test_programs.html#virtual-peripherals).  The [uvme_cv32e20_vp_status_flags_seq.sv](https://github.com/openhwgroup/cv32e20-dv/blob/496e44a0c6c7b6b11ca2e1aaff383ca17134f37a/env/uvme/vseq/uvme_cv32e20_vp_status_flags_seq.sv#L94) interprets any non-zero value as a failure code.
2. **tests/programs/custom/riscv_arithmetic_basic_test_0/riscv_arithmetic_basic_test_0.S**: I have no idea how this could have gotten so messed up, but this test-program is simply never going to work in this environment.  It was using a symbol called `_test_pass` which does not exist.  I made two important fixes:
   - replaced `_test_passed` with `test_done`.
   - fixed the `fast_exit` code segment to write `test_results` to the virtual peripheral status flags.