### PR TITLE
Fix memory leak in UVM tb

### DIFF
--- a/env/uvme/uvme_cv32e20_env.sv
+++ b/env/uvme/uvme_cv32e20_env.sv
@@ -191,6 +191,16 @@ function void uvme_cv32e20_env_c::build_phase(uvm_phase phase);
 
       $value$plusargs("scoreboard_enable=%0h", cfg.scoreboard_enabled);
 
+      // The RVFI scoreboard pushes one transaction per retired instruction into
+      // its core/reference_model queues but only drains them when +USE_ISS is set.
+      // Building the scoreboard without +USE_ISS therefore grows those queues
+      // unbounded (a memory leak, very evident under DSim).
+      // To prevent this, we disable the scoreboard here if +USE_ISS is not set.
+      if (cfg.scoreboard_enabled && !$test$plusargs("USE_ISS")) begin
+         `uvm_info("UVME_CV32E20_ENV", "Disabling RVFI scoreboard because +USE_ISS not set.", UVM_LOW)
+         cfg.scoreboard_enabled = 0;
+      end
+
       retrieve_vifs        ();
       assign_cfg           ();
       assign_cntxt         ();

--- a/env/uvme/uvme_cv32e20_env.sv
+++ b/env/uvme/uvme_cv32e20_env.sv
@@ -197,7 +197,7 @@ function void uvme_cv32e20_env_c::build_phase(uvm_phase phase);
       // unbounded (a memory leak, very evident under DSim).
       // To prevent this, we disable the scoreboard here if +USE_ISS is not set.
       if (cfg.scoreboard_enabled && !$test$plusargs("USE_ISS")) begin
-         `uvm_info("UVME_CV32E20_ENV", "Disabling RVFI scoreboard because +USE_ISS not set.", UVM_LOW)
+         `uvm_warning("UVME_CV32E20_ENV", "Disabling RVFI scoreboard because +USE_ISS not set.")
          cfg.scoreboard_enabled = 0;
       end
 

--- a/tb/core/cv32e20_tb_wrapper.sv
+++ b/tb/core/cv32e20_tb_wrapper.sv
@@ -114,7 +114,7 @@ module cv32e20_tb_wrapper
          .irq_timer_i            ( irq_from_mm_ram[7]    ),
          .irq_external_i         ( irq_from_mm_ram[11]   ),
          .irq_fast_i             ( irq_from_mm_ram[31:16]),
-         .irq_nm_i               (  1'b0                 ),       // non-maskeable interrupt
+         .irq_nm_i               ( 1'b0                  ), // TODO: non-maskeable interrupt
 
          .debug_req_i            ( debug_req             ),
          .dm_halt_addr_i         ( DM_HALTADDRESS        ),

--- a/tb/uvmt/uvmt_cv32e20_dut_wrap.sv
+++ b/tb/uvmt/uvmt_cv32e20_dut_wrap.sv
@@ -47,6 +47,7 @@ module uvmt_cv32e20_dut_wrap #(
                             uvma_interrupt_if            interrupt_if,
                             // vp_status_if is driven by ENV and used in TB
                             uvma_interrupt_if            vp_interrupt_if,
+                            uvma_debug_if                debug_if,
                             uvme_cv32e20_core_cntrl_if   core_cntrl_if,
                             uvmt_cv32e20_core_status_if  core_status_if,
                             uvma_obi_memory_if           obi_memory_instr_if,
@@ -173,17 +174,17 @@ module uvmt_cv32e20_dut_wrap #(
          .x_result_i             ( '0                             ),
 
   // Interrupt inputs
-         .irq_software_i         ( 1'b0/*irq_uvma[3]*/),
-         .irq_timer_i            ( 1'b0/*irq_uvma[7]*/),
-         .irq_external_i         ( 1'b0/*irq_uvma[11]*/),
-         .irq_fast_i             ( 16'h0000/*irq_uvma[31:16]*/),
-         .irq_nm_i               ( 1'b0/*irq_uvma[0]*/),       // non-maskeable interrupt
+         .irq_software_i         ( irq_uvma[3]                    ),
+         .irq_timer_i            ( irq_uvma[7]                    ),
+         .irq_external_i         ( irq_uvma[11]                   ),
+         .irq_fast_i             ( irq_uvma[31:16]                ),
+         .irq_nm_i               ( 1'b0 /*irq_uvma[0]*/           ), // TODO: non-maskeable interrupt
 
   // Debug Interface
-         .debug_req_i             ( 1'b0/*debug_req_uvma*/),
+         .debug_req_i             ( debug_req_uvma ),
          .debug_halted_o          (),
-         .dm_halt_addr_i          ( 32'h1A11_0800 ),
-         .dm_exception_addr_i     ( 32'h1A14_0000 ),
+         .dm_halt_addr_i          ( 32'h1A11_0800  ),
+         .dm_exception_addr_i     ( 32'h1A14_0000  ),
          .crash_dump_o            (),
 
   // RISC-V Formal Interface


### PR DESCRIPTION
The primary purpose of this PR is to fix a memory leak in the UVM environment.  With the memory leak fixed it made sense to connect the debug and interrupt agents as well.