### PR TITLE
Cleaned-up debug_test (all sub-tests passing)

### DIFF
--- a/sim/ExternalRepos.mk
+++ b/sim/ExternalRepos.mk
@@ -10,10 +10,13 @@
 
 export SHELL = /bin/bash
 
-CV_CORE_REPO   ?= https://github.com/openhwgroup/cve2
-CV_CORE_BRANCH ?= main
-CV_CORE_HASH   ?= b72358c
+#CV_CORE_REPO   ?= https://github.com/openhwgroup/cve2
+#CV_CORE_BRANCH ?= main
+#CV_CORE_HASH   ?= a24bbd2
 
+CV_CORE_REPO   ?= https://github.com/MikeOpenHWGroup/cve2
+CV_CORE_BRANCH ?= umode
+CV_CORE_HASH   ?= f217917
 
 CV_VERIF_REPO   ?= https://github.com/openhwgroup/core-v-verif
 CV_VERIF_BRANCH ?= cv32e20-dv/dev

--- a/tests/programs/custom/debug_test/README.md
+++ b/tests/programs/custom/debug_test/README.md
@@ -1,0 +1,119 @@
+# debug_test
+
+A directed test that exercises the **CV32E20** run-control debug and trigger
+features against the RISC-V Debug Specification (v0.13.2) and the CV32E20 User
+Manual. It runs bare-metal on the core testbench (Verilator + `tb/core`).
+
+The test drives debug entry three ways — external halt request (`debug_req_i`),
+`ebreak`, and single-step — and checks the resulting `dcsr`/`dpc`/`mepc`/`mcause`/
+`mtval` state, CSR access rules, exception behaviour in debug mode, and the
+trigger CSRs.
+
+> **CV32E20 is M-mode only** (requirement PVL-20). Several sub-tests were
+> originally written for the U-mode-capable cv32e40p and have been ported to the
+> M-only CV32E20 (see [CV32E20-specific notes](#cv32e20-specific-notes)).
+
+## Source files
+
+| File | Role |
+|------|------|
+| `debug_test.c` | Test driver / `main`. Sequences the tests, drives `debug_req_i`, checks status globals. |
+| `debugger.S` | The "debugger" — code executed in Debug Mode (entered at `dm_halt_addr`). Dispatches on `glb_hart_status` / `glb_step_info`. |
+| `debugger_exception.S` | Debug-mode exception handler (entered at `dm_exception_addr`), e.g. illegal CSR / `ecall` while in Debug Mode. |
+| `handlers.S` | M-mode trap vector + handlers: illegal-instruction, `ebreak`, `ecall`, IRQ (`__no_irq_handler`). |
+| `single_step.S` | The single-step exercise driven by Test 18 (`_single_step`), with sub-tests selected by `glb_step_info`. |
+| `trigger_code.S` | Code region used as a trigger-match target. |
+| `test.yaml` | Test definition. |
+
+### Key status globals (driver ↔ debugger handshake)
+- `glb_hart_status` — selects which debugger routine runs in Debug Mode.
+- `glb_debug_status` — set by the debugger; the driver polls it to confirm completion.
+- `glb_step_info` — selects the single-step sub-test (Test 18).
+- `glb_expect_debug_entry` / `glb_expect_debug_exception` / `glb_expect_illegal_insn` /
+  `glb_expect_ebreak_handler` / `glb_expect_irq_entry` — "expected event" flags; a
+  handler entered without its flag set fails the test.
+- `glb_illegal_insn_status`, `glb_ebreak_status`, `glb_step_count` — running counters.
+
+## Running
+
+```
+make -C sim/core test TEST=debug_test \
+  CFLAGS="-Os -g -static -mabi=ilp32 -march=rv32imc_zicsr_zifencei -Wno-error=implicit-function-declaration" \
+  VERI_RUN_FLAGS="+maxcycles=2000000"
+```
+
+Pass is reported by the testbench as `ALL TESTS PASSED`; the program asserts the
+pass signature (`*0x20000000 = 123456789`) on reaching the end of `main`. Any
+failed check writes a non-zero value to `0x20000000` (`TEST_FAILED`).
+Log: `sim/core/simulation_results/debug_test/0/test_program/debug_test.log`.
+
+## Test summary
+
+Tests are numbered historically; some numbers are unimplemented placeholders and
+the **execution order is not strictly numeric** (see below).
+
+| Test | Purpose |
+|------|---------|
+| **1** | Read initial `mstatus` / `mie` values. |
+| **2** | Debug & Trigger CSR access rules. |
+| 2.1 | Read/write of Debug CSRs (`dcsr`,`dpc`,`dscratch0/1`) **outside** Debug Mode → illegal-instruction exception. |
+| 2.2 | Writes to Trigger CSRs (`tselect`,`tdata1/2/3`) outside Debug Mode are ignored; `tinfo`/`mcontext`/`scontext` handled (see notes). |
+| 2.3 | Reads of Trigger CSRs return defaults; `tinfo` (`0x7a4`) and non-existent CSR (`0xea8`) reads → illegal. |
+| **3** | `EBREAK` with `dcsr.ebreakm`=0. |
+| 3.1 | `c.ebreak` runs the M-mode ebreak **handler** (not the debugger). |
+| 3.2 | uncompressed `ebreak` — same. |
+| **4** | **Debugger Simple:** assert `debug_req_i` (halt request) → enter Debug Mode; debugger checks `dcsr` cause = halt-req. |
+| **5** | **Debugger Ebreak:** debugger executes `ebreak` 3× (incl. compressed), re-entering Debug Mode each time. |
+| **6** | **Debugger CSR:** read Machine + Debug + Trigger CSRs in Debug Mode; check `dcsr` and `tdata1` defaults. |
+| 7–9 | *Not implemented (placeholders).* |
+| **10** | **Debugger Ebreak Entry:** `ebreak` with `dcsr.ebreakm`=1 enters the **debugger**; check entry cause. |
+| **11** | Illegal-CSR access in Debug Mode → debug-mode exception (debugger-exception handler); CSRs unmodified. |
+| **12** | `ecall` in Debug Mode → debug-mode exception. |
+| **13** | `mret` in Debug Mode → debug-mode exception. *(currently `ecall` stands in for `mret` in `debugger.S`.)* |
+| **14** | Exception path entering debug: illegal insn → handler executes `c.ebreak` → Debug Mode. |
+| 15 | *Not implemented.* |
+| **16** | `dret` executed in M-mode (outside Debug) → illegal-instruction exception. |
+| **17** | `WFI` before `debug_req_i`, and `WFI` in Debug Mode (must behave as `NOP`; test hangs if not). |
+| *(irq check)* | Assert & service a timer IRQ — prerequisite plumbing for later tests. |
+| **21** | `dcsr.stopcount`=1 has no effect (`mcycle`/`minstret` still advance). *(runs before 18)* |
+| **18** | **Single stepping** — see [sub-tests](#test-18-single-step-sub-tests). |
+| **19** | IRQ asserted while in Debug Mode is **not** taken until debug exit (timeout-checked). |
+| **20** | `debug_req_i` and IRQ asserted on the same cycle — debug entry vs. interrupt timing. |
+| **22** | `fence` / `fence.i` execute in Debug Mode. |
+| **23** | Trigger with match **disabled** does not fire in Debug Mode. |
+| **24** | Trigger register R/W in Debug Mode (`tdata3`, `tselect`) to close coverage holes. |
+
+**Execution order:** 1, 2.x, 3, 4, 5, 6, 10, 11, 12, 13, 14, 16, 17, *(irq check)*,
+21, 18, 19, 20, 22, 23, 24.
+
+### Test 18 single-step sub-tests
+
+Selected by `glb_step_info` in `single_step.S` / `debugger.S`:
+
+| `step_info` | Sub-test |
+|:-----------:|----------|
+| 1 | Enable single-step (`dcsr.step`), advance `dpc` past the entry `ebreak`. |
+| 0 | Normal single-step: `dpc` advances by 2/4 each step. |
+| 3 | Step over an **illegal** instruction (`csrr dcsr`, then `dret`-in-M): step enters Debug at the trap vector; `mtval` holds the faulting instruction. |
+| 4 | **Trigger match** during single-step (execute match on `_step_trig_point`). |
+| 5, 6 | *Stepping with interrupts (`stepie`=1/0).* **SKIPPED** — `dcsr.stepie` is **not implemented** on CV32E20 (interrupts always masked during step). Code preserved behind `j _skip_stepie_tests` for a separate feature review. |
+| 7, 8 | `c.ebreak` / `ebreak` with `dcsr.ebreakm`=1 during step — ebreak vs. step cause priority (ebreak wins). |
+| 9, 10 | `ebreak` / `c.ebreak` with `dcsr.ebreakm`=0 during step — breakpoint exception to the M-mode handler; `ebreakm` restored afterwards. |
+| 2 | Disable single-step. |
+
+## CV32E20-specific notes
+
+These reflect the M-only / reduced feature set of CV32E20; the RTL and the
+CV32E20 manual are authoritative, and the test was adapted to match:
+
+- **M-mode only (PVL-20).** No U-mode. The trigger `mcontrol.u` bit reads 0, so
+  `tdata1` reads `0x28001040` (Tests 2.3 and 6). `dcsr.prv` WARL-clamps to M.
+- **`mtval` holds the faulting instruction** on illegal-instruction exceptions
+  (and is sticky), unlike cv32e40p's `mtval`==0. Test 18 does not assert `mtval`==0.
+- **`dcsr.stepie` not implemented** (bit 11 reads 0): interrupts are always
+  masked while single-stepping. Test 18 `step_info` 5/6 are skipped.
+- **`tinfo` (`0x7a4`) not implemented:** any access raises an illegal instruction
+  (verified by Test 2.x). Test 24 does not access `tinfo`.
+- **Single-step over a trapping instruction** (illegal / `ebreak`-without-`ebreakm`)
+  enters Debug Mode at the trap handler's first PC with `dcsr.cause`=step, then the
+  handler is itself single-stepped.

--- a/tests/programs/custom/debug_test/debug_test.c
+++ b/tests/programs/custom/debug_test/debug_test.c
@@ -291,14 +291,14 @@ int main(int argc, char *argv[])
 
     printf("        - Trigger TDATA1 read check\n");
     __asm__ volatile("csrr %0, 0x7a1"   : "=r"(temp)); // Trigger TDATA1
-    // TBC: does CV32E20 support matching in User Mode?
+    // CV32E20 is M-only (PVL-20), so the trigger u(ser) bit reads 0.
     //   31:28 type      = 2
     //      27 dmode     = 1
     //   15:12 action    = 1
     //      6  m(achine) = 1
-    //      3  u(ser)    = 1
-    if(temp !=  (2<<28 | 1<<27 | 1<<12 | 1<<6 | 1<<3)) {
-        printf(": ERROR!  Expected 0x2800_1048\n");
+    //      3  u(ser)    = 0
+    if(temp !=  (2<<28 | 1<<27 | 1<<12 | 1<<6)) {
+        printf(": ERROR!  Expected 0x2800_1040\n");
         TEST_FAILED;
     }
 
@@ -543,24 +543,17 @@ int main(int argc, char *argv[])
     }
     check_debug_status(121, glb_hart_status);
 
-    // NOTE: Tests 18-24 (single-step, irq-in-debug, fence-in-debug, triggers)
-    // are SKIPPED for now.  They were written against cv32e40p semantics and
-    // need porting to CV32E20, which implements U-mode and writes the faulting
-    // instruction into mtval on illegal-instruction exceptions.  Deferred
-    // pending CV32E20 debug-feature updates (incl. possible U-mode deprecation).
-    // The suite currently passes Tests 1-17 and 21.
-    printf("\n\nTests 18-24 skipped (pending CV32E20 debug-feature port) - ending here.\n\n");
-    TEST_PASSED;
-
     printf("------------------------\n");
     printf("Test 18: Single stepping\n");
     glb_hart_status = 18;
+    // Single step code generates 2 illegal insn (csrr dcsr + dret).  Capture the
+    // cumulative count before stepping so the check is robust to prior tests'
+    // counts (the original used an unrelated scratch variable).
+    temp1 = glb_illegal_insn_status + 2;
     // Run single step code (in single_step.S)
     _single_step(0);
 
-    // Single step code should generate 2 illegal insn
-    temp1++;
-    check_illegal_insn_status("Test 18", temp1++);
+    check_illegal_insn_status("Test 18", temp1);
     check_debug_status(118, glb_hart_status);
 
     printf("Stepped %d times\n", glb_step_count);
@@ -637,5 +630,7 @@ int main(int argc, char *argv[])
     //return EXIT_FAILURE;
     printf("------------------------\n");
     printf("Finished \n");
+    // Reached the natural end with no check having failed -> signal pass.
+    TEST_PASSED;
     return EXIT_SUCCESS;
 }

--- a/tests/programs/custom/debug_test/debug_test.c
+++ b/tests/programs/custom/debug_test/debug_test.c
@@ -297,8 +297,11 @@ int main(int argc, char *argv[])
     //   15:12 action    = 1
     //      6  m(achine) = 1
     //      3  u(ser)    = 0
-    if(temp !=  (2<<28 | 1<<27 | 1<<12 | 1<<6)) {
-        printf(": ERROR!  Expected 0x2800_1040\n");
+    const unsigned int expected_tdata1 = (2<<28 | 1<<27 | 1<<12 | 1<<6);
+    if(temp !=  expected_tdata1) {
+        printf("ERROR!  Expected 0x%04x_%04x, got 0x%04x_%04x\n",
+                expected_tdata1 >> 16, expected_tdata1 & 0xff,
+                temp >> 16,            temp & 0xff);
         TEST_FAILED;
     }
 

--- a/tests/programs/custom/debug_test/debugger.S
+++ b/tests/programs/custom/debug_test/debugger.S
@@ -115,13 +115,11 @@ _debugger_start:
     li t0, 24
     beq t2, t0, _debugger_trigger_regs_access
 _debugger_trigger_regs_access:
-    # R/W trigger regs otherwise not accessed
-    # to close coverage holes
-    li t0, 0xff
-    csrw 0x7a4, t0 # tinfo
-    csrr t0, 0x7a4
-    li t1, 4
-    bne t0, t1, _debugger_fail
+    # R/W trigger regs otherwise not accessed to close coverage holes.
+    # NOTE: tinfo (0x7a4) is NOT implemented on CV32E20 (absent from the CSR
+    # map), so any access raises an illegal instruction - Test 2.x already
+    # verifies that.  The original cv32e40p tinfo write/read (expect 4) is
+    # removed here.
     li t0, 0xff
     csrw 0x7a3, t0 # tdata3
     csrr t0, 0x7a3
@@ -219,7 +217,7 @@ _debugger_single_step_enable:
     li t1, 4<<28 | 1<<15 | 1<<6 | 3<<0
     bne t0, t1, _debugger_fail
     // Enable step bit in dcsr
-    li t0, 4<<28 | 1<<15 | 1<<2 
+    li t0, 4<<28 | 1<<15 | 1<<2
     csrw dcsr, t0
     // ebreak used to enter single step test, incr dpc
     csrr t0, dpc
@@ -331,12 +329,15 @@ _inc_dpc_ebreak:
 _debugger_single_step_ebreak_exception:
     j _debugger_single_step_end
 _debugger_single_step_cebreak_exception:
-    #  depc != 0 => we have passed the first
-    # instruction of the handler, and we can
-    # set dcsr.ebreakm again
-    csrr t0, dpc
-    bne t0, x0, _end
-    
+    # ebreakm was turned off (step_info==8) so this c.ebreak takes a breakpoint
+    # exception.  Restore ebreakm once the ebreak handler has actually run, so
+    # the following sub-tests see ebreakm=1.
+    # NOTE: the original gate (dpc==0) never holds on CV32E20 (dpc is always the
+    # handler address), so ebreakm was never restored.  Use the handler-run
+    # signal instead: handle_ebreak clears glb_expect_ebreak_handler.
+    la t0, glb_expect_ebreak_handler
+    lw t0, 0(t0)
+    bne t0, x0, _end          # handler not yet run -> keep ebreakm off
     li t1, 4<<28 | 1<<15 | 1<<6 | 1<<2 | 3<<0
     csrw dcsr, t1
 _end:
@@ -346,9 +347,11 @@ _debugger_single_step_basic:
     li t1, 4<<28 | 1<<15 | 2<<6 | 1<<2 | 3<<0
     csrr t2, dcsr
     beq t1, t2, _debugger_step_trig_entry
-    // Ensure tval (0x343) always == 0
-    csrr t1, 0x343
-    bne x0, t1, _debugger_fail
+    // NOTE: the original cv32e40p test asserted mtval (0x343) == 0 here.
+    // CV32E20 writes the faulting instruction into mtval on illegal-insn
+    // exceptions and mtval is sticky, so after the step_info==3 illegal
+    // instructions it is legitimately non-zero for all later steps.  The
+    // mtval==0 assertion is invalid on CV32E20 and has been removed.
 //            ebreakm   step  stepen
     li t1, 4<<28 | 1<<15 | 4<<6 | 1<<2 | 3<<0
     bne t1, t2, _debugger_fail
@@ -460,8 +463,8 @@ _debugger_csr:
     //      27 dmode     = 1
     //   15:12 action    = 1
     //      6  m(achine) = 1
-    //      3  u(ser)    = 1
-    li   t1, 2<<28 | 1<<27 | 1<<12 | 1<<6 | 1<<3
+    //      3  u(ser)    = 0 (M-only)
+    li   t1, 2<<28 | 1<<27 | 1<<12 | 1<<6
     csrr t2,tdata1
     bne  t1,t2,_debugger_fail
     csrr t2,tselect

--- a/tests/programs/custom/debug_test/handlers.S
+++ b/tests/programs/custom/debug_test/handlers.S
@@ -252,9 +252,17 @@ cont_illegal_insn:
     //clear glb_expect_illegal_insn
     sw x0, 0(a0)
 	//indicate that this was expected...
+    // During Test 18 single-step we step through this handler one instruction
+    // at a time; the puts() -> newlib loop is catastrophically slow. Skip the
+    // message during Test 18 only (hart_status==18) to stay within maxcycles.
+    la t1, glb_hart_status
+    lw t1, 0(t1)
+    li t2, 18
+    beq t1, t2, skip_illegal_puts
     la a0, expected_illegal_insn_msg
     jal ra, puts
-    //increment hart status     
+skip_illegal_puts:
+    //increment hart status
     la a0, glb_illegal_insn_status  
     lw t0, 0(a0)
     addi t0,t0,1

--- a/tests/programs/custom/debug_test/single_step.S
+++ b/tests/programs/custom/debug_test/single_step.S
@@ -96,6 +96,13 @@ _step_trig_exit:
     // loading of t0 to 1, and t0 should be of value 2
     bne t0, t1, _single_step_fail
 
+    // CV32E20 does NOT implement dcsr.stepie (bit 11 reads 0; the CV32E20 dcsr
+    // spec lists the implemented fields and states "Other bit fields read as
+    // zero").  Interrupts are therefore always masked during single-step, so
+    // the stepie=1/0 sub-tests (step_info 5 & 6) exercise interrupt-enabled
+    // single-stepping, which is unimplemented.  Skip them here; the code is
+    // preserved below for the separate stepie-feature review.
+    j _skip_stepie_tests
 
     //-----------------
     // Stepping with interrupt, stepie=1
@@ -154,6 +161,7 @@ _irq_wait_loop:
     nop
     nop
 
+_skip_stepie_tests:
     # set step reason to 7 (step with c.ebreak)
     la a1, glb_step_info
     li t0, 7

--- a/tests/programs/custom/fibonacci/fibonacci.c
+++ b/tests/programs/custom/fibonacci/fibonacci.c
@@ -19,6 +19,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#define TEST_PASSED  *(volatile int *)0x20000000 = 123456789
+#define TEST_FAILED  *(volatile int *)0x20000000 = 1
+
 static int fib(int i) {
     return (i>1) ? fib(i-1) + fib(i-2) : i;
 }
@@ -26,7 +29,7 @@ static int fib(int i) {
 int main(int argc, char *argv[]) {
 
     int i;
-    int num = (argc >= 2) ? atoi((const char *)argv[1]) : 15;
+    int num = (argc >= 2) ? atoi((const char *)argv[1]) : 16;
 
     printf("starting fib(%d)...\n", num);
 
@@ -35,6 +38,8 @@ int main(int argc, char *argv[]) {
     }
 
     printf("finishing...\n");
+
+    TEST_PASSED;
 
     return 0;
 }

--- a/tests/programs/custom/hello-world/hello-world.c
+++ b/tests/programs/custom/hello-world/hello-world.c
@@ -29,7 +29,7 @@
 
 // MVENDORID CSR: 0x602 is the value assigned by JEDEC to the OpenHW Group
 #define EXP_MVENDORID 0x00000602
-#define EXP_MISA      0x40101104
+#define EXP_MISA      0x40001104
 #define EXP_MARCHID   0x00000023
 #define EXP_MIMPID    0x00000000
 
@@ -56,6 +56,7 @@ int main(int argc, char *argv[])
 
     if (misa_rval != EXP_MISA) {
       printf("\tERROR: CSR MISA reads as 0x%x - should be 0x%x for this release of CV32E20!\n\n", misa_rval, EXP_MISA);
+      TEST_FAILED;
     }
 
     if (marchid_rval != EXP_MARCHID) {


### PR DESCRIPTION
With this update, the debug_test is now completely passing.  Note that this requires changes to the RTL, see [CVE2 PR #333](https://github.com/openhwgroup/cve2/pull/333), so the `External.mk` file has been updated to point to my cloen of the RTL.