### PR TITLE
Integrate corev-dv tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ ucli.key
 vcs.cmd
 venv*
 /dist/
+.claude

--- a/bin/run_tests.py
+++ b/bin/run_tests.py
@@ -68,7 +68,7 @@ PATH, as for a normal `make test`.
     # Other options:
     #   --cfg NAME      uvmt config subdirectory                (default: default)
     #   --run-index N   RUN_INDEX subdirectory                  (default: 0)
-    #   --timeout SECS  per-test timeout                        (default: 600)
+    #   --timeout SECS  per-test timeout                        (default: 1800)
     #   --quiet         suppress per-test simulation banners
     #   -h / --help     full option help
 
@@ -78,6 +78,7 @@ suitable for use as a CI gate.
 
 import argparse
 import os
+import signal
 import subprocess
 import sys
 from pathlib import Path
@@ -100,7 +101,7 @@ TESTBENCHES = {
     },
     "uvmt": {
         "sim_dir": REPO / "sim" / "uvmt",
-        "make_args": ["SIMULATOR=vsim"],
+        "make_args": ["SIMULATOR=vsim", "USE_ISS=NO"],
         "pass_banner": "SIMULATION PASSED",
         "fail_banner": "SIMULATION FAILED",
         "markers": ("SIMULATION PASSED", "SIMULATION FAILED",
@@ -166,7 +167,7 @@ PARKED = [
 # templates under tests/programs/corev-dv/.  Unlike C_TESTS/ASM_TESTS/PARKED,
 # each of these needs its randomized test program generated before it can be
 # built and run, i.e. `make gen_corev-dv test TEST=<name>` rather than plain
-# `make test TEST=<name>` -- run_test() adds the extra target automatically for
+# `make test TEST=<name>`, where run_test() adds the extra target automatically for
 # names in this list. Meaningful only under --tb uvmt (corev-dv generation is
 # wired up for the uvmt testbench only); included only with --include-corev-dv
 # or --corev-dv-only.
@@ -175,30 +176,15 @@ PARKED = [
 # corev-dv/riscv-dv packages) must have been run once in sim/uvmt; main() does
 # this automatically whenever the selected set includes a corev-dv test.
 #
-# This is the set confirmed passing (0 UVM_ERROR/UVM_FATAL, clean end-of-test)
-# with SIMULATOR=vsim as of 2026-07-14, after: the mk/uvmt/uvmt.mk corev-dv
-# path-wiring fix and OPT_RUN_INDEX_SUFFIX fix; the exception_req_withdrawn SVA
-# fix in core-v-cores/cv32e20/rtl/cve2_controller.sv (verification-only
-# bookkeeping, no functional RTL change); the RVFI-gated interrupt-noise
-# throttle in env/uvme/vseq/uvme_cv32e20_interrupt_noise_vseq.sv; and reverting
-# the id_in_ready driver-side wait in uvma_interrupt_drv.sv/uvma_debug_drv.sv
-# (it could deadlock a core parked in WFI).  See
-# E20DV/tmp/exception_req_pending_finding.md and the cv32e20-corev-dv-restore
-# project memory for the full investigation.
-#
-# Not yet included:
-#   * corev_rand_interrupt_exception -- completes cleanly (no livelock) but
-#     still hits one residual CVE2SetExceptionPCOnSpecialReqIfExpected
-#     assertion during a rapid back-to-back exception-retrigger burst; root
-#     cause not yet confirmed.
-#   * corev_rand_debug, corev_rand_debug_ebreak, corev_rand_debug_single_step,
-#     corev_rand_illegal_instr_test, corev_rand_instr_long_stall -- not yet run
-#     against the current fixes.
+# Not yet included: corev_rand_debug, corev_rand_debug_ebreak,
+# corev_rand_debug_single_step, corev_rand_illegal_instr_test,
+# corev_rand_instr_long_stall -- not yet run against the current fixes.
 COREV_DV_TESTS = [
     "corev_rand_arithmetic_base_test",
     "corev_rand_instr_test",
     "corev_rand_interrupt",
     "corev_rand_interrupt_debug",
+    "corev_rand_interrupt_exception",
     "corev_rand_interrupt_nested",
     "corev_rand_interrupt_wfi",
     "corev_rand_interrupt_wfi_mem_stress",
@@ -238,6 +224,30 @@ def make_env(tbcfg):
     return env
 
 
+def _run(cmd, cwd, env, timeout, capture):
+    """Run cmd in its own process group (session) so a timeout can kill the
+    whole tree, not just the immediate child. Without this, a `make` that
+    times out leaves its own child (e.g. vsim) running as an orphan: the
+    simulation keeps going for real in the background while the script
+    reports a false timeout and moves on to the next test."""
+    proc = subprocess.Popen(
+        cmd,
+        cwd=cwd,
+        env=env,
+        start_new_session=True,
+        stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.PIPE if capture else None,
+        text=True,
+    )
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        proc.communicate()
+        raise
+    return proc.returncode, stdout, stderr
+
+
 def setup_corev_dv(tb, timeout):
     """Run `make corev-dv` once: clones and compiles the corev-dv/riscv-dv
     packages.  Required before any COREV_DV_TESTS entry can build; aborts the
@@ -248,14 +258,14 @@ def setup_corev_dv(tb, timeout):
 
     print(f"[Setup/{tb}] make corev-dv ...")
     try:
-        proc = subprocess.run(cmd, cwd=tbcfg["sim_dir"], timeout=timeout, env=env)
+        returncode, _, _ = _run(cmd, tbcfg["sim_dir"], env, timeout, capture=False)
     except subprocess.TimeoutExpired:
         sys.exit(f"error: 'make corev-dv' timed out after {timeout}s")
     except OSError as exc:
         sys.exit(f"error: could not launch 'make corev-dv': {exc}")
 
-    if proc.returncode != 0:
-        sys.exit(f"error: 'make corev-dv' failed (exit {proc.returncode}); "
+    if returncode != 0:
+        sys.exit(f"error: 'make corev-dv' failed (exit {returncode}); "
                   "no corev-dv test can build without it")
 
 
@@ -263,32 +273,32 @@ def run_test(tb, test, run_index, cfg, timeout, quiet):
     """Build+run one test on the chosen testbench; return (outcome, detail)."""
     tbcfg = TESTBENCHES[tb]
     targets = ["gen_corev-dv", "test"] if test in COREV_DV_TESTS else ["test"]
-    cmd = (["make"] + targets + [f"TEST={test}", f"RUN_INDEX={run_index}"]
-           + tbcfg["make_args"])
+    cmd = ["make"] + targets + [f"TEST={test}", f"RUN_INDEX={run_index}"]
+    if test in COREV_DV_TESTS:
+        # gen_corev-dv generates into <test>/$(GEN_START_INDEX)/test_program/,
+        # independently of RUN_INDEX (which only selects where the build/run
+        # step looks for that program). Without this, a non-zero --run-index
+        # generates into .../0/ but builds/runs out of .../<run_index>/, which
+        # is empty except for the BSP.
+        cmd.append(f"GEN_START_INDEX={run_index}")
+    cmd += tbcfg["make_args"]
     env = make_env(tbcfg)
 
     try:
-        proc = subprocess.run(
-            cmd,
-            cwd=tbcfg["sim_dir"],
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            env=env,
-        )
+        returncode, stdout, stderr = _run(cmd, tbcfg["sim_dir"], env, timeout, capture=True)
     except subprocess.TimeoutExpired:
         return "ERROR", f"timed out after {timeout}s"
     except OSError as exc:
         return "ERROR", f"could not launch make: {exc}"
 
     if not quiet:
-        for line in proc.stdout.splitlines():
+        for line in stdout.splitlines():
             if any(m in line for m in tbcfg["markers"]):
                 print("    " + line)
 
     # The console output is authoritative for the run we just launched; fall
     # back to the on-disk log if the banner did not reach stdout.
-    console = proc.stdout + proc.stderr
+    console = stdout + stderr
     outcome = classify(console, tbcfg)
     if outcome == "ERROR":
         path = log_path(tb, test, run_index, cfg)
@@ -297,8 +307,8 @@ def run_test(tb, test, run_index, cfg, timeout, quiet):
 
     if outcome != "ERROR":
         return outcome, ""
-    if proc.returncode != 0:
-        return "ERROR", f"make exited {proc.returncode}"
+    if returncode != 0:
+        return "ERROR", f"make exited {returncode}"
     return "ERROR", "no verdict banner"
 
 
@@ -334,8 +344,10 @@ def main():
                     help="uvmt config subdirectory under vsim_results (default: default)")
     ap.add_argument("--run-index", type=int, default=0,
                     help="RUN_INDEX subdirectory to use (default: 0)")
-    ap.add_argument("--timeout", type=int, default=600,
-                    help="per-test timeout in seconds (default: 600)")
+    ap.add_argument("--timeout", type=int, default=1800,
+                    help="per-test timeout in seconds (default: 1800; the "
+                         "interrupt-heavy corev-dv templates routinely take "
+                         "10-15 minutes including compile)")
     ap.add_argument("--quiet", action="store_true",
                     help="suppress per-test simulation banner output")
     args = ap.parse_args()

--- a/bin/run_tests.py
+++ b/bin/run_tests.py
@@ -7,7 +7,7 @@ testbench and print a pass/fail summary.  Either testbench can be selected
 with --tb:
 
     core   the Verilator core testbench in sim/core            (default)
-    uvmt   the UVM testbench in sim/uvmt, run with SIMULATOR=dsim
+    uvmt   the UVM testbench in sim/uvmt, run with SIMULATOR=vsim
 
 For each selected test the script invokes `make test TEST=<name> ...` in the
 chosen testbench's sim directory, then parses the per-test log it leaves behind
@@ -17,7 +17,7 @@ for the verdict banner:
            "ALL TESTS PASSED"   -> PASS   (tb/core/tb_top.sv)
            "TEST(S) FAILED!"    -> FAIL
 
-    uvmt : sim/uvmt/dsim_results/<cfg>/<name>/<run>/dsim-<name>.log
+    uvmt : sim/uvmt/vsim_results/<cfg>/<name>/<run>/vsim-<name>.log
            "SIMULATION PASSED"  -> PASS   (tb/uvmt/uvmt_cv32e20_tb.sv;
                                            includes "PASSED with WARNINGS")
            "SIMULATION FAILED"  -> FAIL
@@ -25,33 +25,45 @@ for the verdict banner:
 Anything else (no banner, build error, timeout) is reported as ERROR.
 The process exit code is 0 only if every test that was run reported PASS.
 
+corev-dv tests (see COREV_DV_TESTS below) additionally need `make corev-dv`
+run once beforehand to clone and compile the corev-dv/riscv-dv packages
+(uvmt only). Whenever the selected set includes any corev-dv test, this
+script runs `make corev-dv` itself before running any tests, and aborts if
+that setup step fails.
+
 Usage
 -----
 The script needs no arguments and can be run from anywhere (paths are resolved
 relative to its own location in <repo>/bin).  A working RISC-V toolchain plus
-the relevant simulator (Verilator for core, Metrics dsim for uvmt) must be on
+the relevant simulator (Verilator for core, Questa vsim for uvmt) must be on
 PATH, as for a normal `make test`.
 
     # Run the full self-checking set (C + assembly) on the core TB:
-    bin/run_c_tests.py
-    python3 bin/run_c_tests.py                 # equivalent
+    bin/run_tests.py
+    python3 bin/run_tests.py                    # equivalent
 
-    # Run the same set on the UVM testbench (dsim):
-    bin/run_c_tests.py --tb uvmt
-    # (equivalent to `make test TEST=<name> SIMULATOR=dsim` per test; the
-    #  script sets SIMULATOR=dsim for you, so no need to export it yourself.)
+    # Run the same set on the UVM testbench (vsim):
+    bin/run_tests.py --tb uvmt
+    # (equivalent to `make test TEST=<name> SIMULATOR=vsim` per test; the
+    #  script sets SIMULATOR=vsim for you, so no need to export it yourself.)
 
     # Run only specific tests (by directory name under tests/programs/custom):
-    bin/run_c_tests.py fibonacci misalign
-    bin/run_c_tests.py --tb uvmt hello-world
+    bin/run_tests.py fibonacci misalign
+    bin/run_tests.py --tb uvmt hello-world
 
     # Also run the parked tests (step-compare / debug; meaningful under --tb uvmt):
-    bin/run_c_tests.py --include-parked
-    bin/run_c_tests.py --tb uvmt --include-parked
+    bin/run_tests.py --include-parked
+    bin/run_tests.py --tb uvmt --include-parked
+
+    # Also run the passing corev-dv generated regression tests (uvmt only):
+    bin/run_tests.py --tb uvmt --include-corev-dv
+
+    # Run ONLY the corev-dv generated regression tests (uvmt only):
+    bin/run_tests.py --tb uvmt --corev-dv-only
 
     # Skip simulation; just re-summarize logs from a previous run:
-    bin/run_c_tests.py --parse-only
-    bin/run_c_tests.py --tb uvmt --parse-only
+    bin/run_tests.py --parse-only
+    bin/run_tests.py --tb uvmt --parse-only
 
     # Other options:
     #   --cfg NAME      uvmt config subdirectory                (default: default)
@@ -88,7 +100,7 @@ TESTBENCHES = {
     },
     "uvmt": {
         "sim_dir": REPO / "sim" / "uvmt",
-        "make_args": ["SIMULATOR=dsim"],
+        "make_args": ["SIMULATOR=vsim"],
         "pass_banner": "SIMULATION PASSED",
         "fail_banner": "SIMULATION FAILED",
         "markers": ("SIMULATION PASSED", "SIMULATION FAILED",
@@ -150,6 +162,49 @@ PARKED = [
     "debug_test_trigger",
 ]
 
+# corev-dv (OpenHW's class extensions of Google's riscv-dv) generated regression
+# templates under tests/programs/corev-dv/.  Unlike C_TESTS/ASM_TESTS/PARKED,
+# each of these needs its randomized test program generated before it can be
+# built and run, i.e. `make gen_corev-dv test TEST=<name>` rather than plain
+# `make test TEST=<name>` -- run_test() adds the extra target automatically for
+# names in this list. Meaningful only under --tb uvmt (corev-dv generation is
+# wired up for the uvmt testbench only); included only with --include-corev-dv
+# or --corev-dv-only.
+#
+# Before any test in this list can build, `make corev-dv` (clone + compile the
+# corev-dv/riscv-dv packages) must have been run once in sim/uvmt; main() does
+# this automatically whenever the selected set includes a corev-dv test.
+#
+# This is the set confirmed passing (0 UVM_ERROR/UVM_FATAL, clean end-of-test)
+# with SIMULATOR=vsim as of 2026-07-14, after: the mk/uvmt/uvmt.mk corev-dv
+# path-wiring fix and OPT_RUN_INDEX_SUFFIX fix; the exception_req_withdrawn SVA
+# fix in core-v-cores/cv32e20/rtl/cve2_controller.sv (verification-only
+# bookkeeping, no functional RTL change); the RVFI-gated interrupt-noise
+# throttle in env/uvme/vseq/uvme_cv32e20_interrupt_noise_vseq.sv; and reverting
+# the id_in_ready driver-side wait in uvma_interrupt_drv.sv/uvma_debug_drv.sv
+# (it could deadlock a core parked in WFI).  See
+# E20DV/tmp/exception_req_pending_finding.md and the cv32e20-corev-dv-restore
+# project memory for the full investigation.
+#
+# Not yet included:
+#   * corev_rand_interrupt_exception -- completes cleanly (no livelock) but
+#     still hits one residual CVE2SetExceptionPCOnSpecialReqIfExpected
+#     assertion during a rapid back-to-back exception-retrigger burst; root
+#     cause not yet confirmed.
+#   * corev_rand_debug, corev_rand_debug_ebreak, corev_rand_debug_single_step,
+#     corev_rand_illegal_instr_test, corev_rand_instr_long_stall -- not yet run
+#     against the current fixes.
+COREV_DV_TESTS = [
+    "corev_rand_arithmetic_base_test",
+    "corev_rand_instr_test",
+    "corev_rand_interrupt",
+    "corev_rand_interrupt_debug",
+    "corev_rand_interrupt_nested",
+    "corev_rand_interrupt_wfi",
+    "corev_rand_interrupt_wfi_mem_stress",
+    "corev_rand_jump_stress_test",
+]
+
 
 def log_path(tb, test, run_index, cfg):
     """Location of the per-test simulation log for the given testbench."""
@@ -157,9 +212,9 @@ def log_path(tb, test, run_index, cfg):
     if tb == "core":
         return (sim_dir / "simulation_results" / test / str(run_index)
                 / "test_program" / f"{test}.log")
-    # uvmt / dsim
-    return (sim_dir / "dsim_results" / cfg / test / str(run_index)
-            / f"dsim-{test}.log")
+    # uvmt / vsim
+    return (sim_dir / "vsim_results" / cfg / test / str(run_index)
+            / f"vsim-{test}.log")
 
 
 def classify(text, tbcfg):
@@ -171,18 +226,46 @@ def classify(text, tbcfg):
     return "ERROR"
 
 
-def run_test(tb, test, run_index, cfg, timeout, quiet):
-    """Build+run one test on the chosen testbench; return (outcome, detail)."""
-    tbcfg = TESTBENCHES[tb]
-    cmd = (["make", "test", f"TEST={test}", f"RUN_INDEX={run_index}"]
-           + tbcfg["make_args"])
-    # SIMULATOR is passed on the make command line above; also export it in the
-    # environment so any sub-make or shell that reads it behaves consistently.
+def make_env(tbcfg):
+    """Environment for a make invocation: os.environ plus tbcfg's make_args
+    (e.g. SIMULATOR=vsim) mirrored in, so any sub-make/shell that reads the
+    variable directly behaves consistently with what's on the command line."""
     env = os.environ.copy()
     for arg in tbcfg["make_args"]:
         key, _, val = arg.partition("=")
         if val:
             env[key] = val
+    return env
+
+
+def setup_corev_dv(tb, timeout):
+    """Run `make corev-dv` once: clones and compiles the corev-dv/riscv-dv
+    packages.  Required before any COREV_DV_TESTS entry can build; aborts the
+    script on failure since no corev-dv test can proceed without it."""
+    tbcfg = TESTBENCHES[tb]
+    cmd = ["make", "corev-dv"] + tbcfg["make_args"]
+    env = make_env(tbcfg)
+
+    print(f"[Setup/{tb}] make corev-dv ...")
+    try:
+        proc = subprocess.run(cmd, cwd=tbcfg["sim_dir"], timeout=timeout, env=env)
+    except subprocess.TimeoutExpired:
+        sys.exit(f"error: 'make corev-dv' timed out after {timeout}s")
+    except OSError as exc:
+        sys.exit(f"error: could not launch 'make corev-dv': {exc}")
+
+    if proc.returncode != 0:
+        sys.exit(f"error: 'make corev-dv' failed (exit {proc.returncode}); "
+                  "no corev-dv test can build without it")
+
+
+def run_test(tb, test, run_index, cfg, timeout, quiet):
+    """Build+run one test on the chosen testbench; return (outcome, detail)."""
+    tbcfg = TESTBENCHES[tb]
+    targets = ["gen_corev-dv", "test"] if test in COREV_DV_TESTS else ["test"]
+    cmd = (["make"] + targets + [f"TEST={test}", f"RUN_INDEX={run_index}"]
+           + tbcfg["make_args"])
+    env = make_env(tbcfg)
 
     try:
         proc = subprocess.run(
@@ -233,15 +316,22 @@ def main():
     ap.add_argument("tests", nargs="*",
                     help="specific test names to run (default: the full cleaned-up set)")
     ap.add_argument("--tb", choices=sorted(TESTBENCHES), default="core",
-                    help="testbench to run on: 'core' (Verilator) or 'uvmt' (dsim) "
+                    help="testbench to run on: 'core' (Verilator) or 'uvmt' (vsim) "
                          "(default: core)")
     ap.add_argument("--include-parked", action="store_true",
                     help="also run the parked tests (step-compare arithmetic/CSR and "
                          "debug variants; meaningful under --tb uvmt)")
+    ap.add_argument("--include-corev-dv", action="store_true",
+                    help="also run the passing corev-dv generated regression tests "
+                         "(uvmt only; each needs an extra gen_corev-dv step)")
+    ap.add_argument("--corev-dv-only", action="store_true",
+                    help="run ONLY the corev-dv generated regression tests (uvmt "
+                         "only); cannot be combined with test names, "
+                         "--include-parked, or --include-corev-dv")
     ap.add_argument("--parse-only", action="store_true",
                     help="do not run; just parse existing logs in the results directory")
     ap.add_argument("--cfg", default="default",
-                    help="uvmt config subdirectory under dsim_results (default: default)")
+                    help="uvmt config subdirectory under vsim_results (default: default)")
     ap.add_argument("--run-index", type=int, default=0,
                     help="RUN_INDEX subdirectory to use (default: 0)")
     ap.add_argument("--timeout", type=int, default=600,
@@ -250,16 +340,29 @@ def main():
                     help="suppress per-test simulation banner output")
     args = ap.parse_args()
 
-    if args.tests:
+    if args.corev_dv_only:
+        if args.tests or args.include_parked or args.include_corev_dv:
+            ap.error("--corev-dv-only cannot be combined with test names, "
+                      "--include-parked, or --include-corev-dv")
+        selected = list(COREV_DV_TESTS)
+    elif args.tests:
         selected = args.tests
     else:
         selected = list(TESTS)
         if args.include_parked:
             selected += PARKED
+        if args.include_corev_dv:
+            selected += COREV_DV_TESTS
 
     sim_dir = TESTBENCHES[args.tb]["sim_dir"]
     if not sim_dir.is_dir():
         sys.exit(f"error: sim directory for --tb {args.tb} not found at {sim_dir}")
+
+    needs_corev_dv = any(test in COREV_DV_TESTS for test in selected)
+    if needs_corev_dv and not args.parse_only:
+        if args.tb != "uvmt":
+            sys.exit("error: corev-dv tests require --tb uvmt")
+        setup_corev_dv(args.tb, args.timeout)
 
     results = []
     width = max(len(t) for t in selected)

--- a/env/corev-dv/cv32e20_asm_program_gen.sv
+++ b/env/corev-dv/cv32e20_asm_program_gen.sv
@@ -294,11 +294,24 @@ class cv32e20_asm_program_gen extends corev_asm_program_gen;
     end
   endfunction
 
+  // Signal end-of-test
+  // In the "core" testbench this is done via the testbench's memory-mapped
+  // test-status port (tb/core/mm_ram.sv). In the "uvmt" environment it is
+  // handled by an OBI Agent virtual sequence (in env/uvme/vseq/uvme_cv32e20_vp_status_flags_seq.sv).
+  // This is the same protocol the directed C/asm tests use
+  // (see bsp/cv32e20_dv.h TEST_PASS / MM_TESTSTATUS_ADDR / TEST_RESULT_PASS).
+  // TODO: use symbols, from the linker script, to get the above symbol values.
   virtual function void gen_test_done();
     string str = format_string("test_done:", LABEL_STR_LEN);
     instr_stream.push_back(str);
-    instr_stream.push_back({indent, "li gp, 1"});
-    instr_stream.push_back({indent, "j write_tohost"});
+    instr_stream.push_back({indent, "csrrci x0, mstatus, 0x8  # clear MSTATUS.MIE"});
+    instr_stream.push_back({indent, "csrrwi x0, mie, 0        # mask all interrupts, final wfi must not wake"});
+    instr_stream.push_back({indent, "li     t0, 0x20000000    # MM_TESTSTATUS_ADDR, see bsp/cv32e20_dv.h"});
+    instr_stream.push_back({indent, "li     t1, 123456789     # TEST_RESULT_PASS, see bsp/cv32e20_dv.h"});
+    instr_stream.push_back({indent, "sw     t1, 0(t0)"});
+    instr_stream.push_back("1:");
+    instr_stream.push_back({indent, "wfi"});
+    instr_stream.push_back({indent, "j 1b"});
   endfunction
 
 endclass : cv32e20_asm_program_gen

--- a/env/uvme/uvme_cv32e20_cntxt.sv
+++ b/env/uvme/uvme_cv32e20_cntxt.sv
@@ -78,12 +78,13 @@ function uvme_cv32e20_cntxt_c::new(string name="uvme_cv32e20_cntxt");
 
    super.new(name);
 
-   clknrst_cntxt          = uvma_clknrst_cntxt_c   ::type_id::create("clknrst_cntxt"         );
-   interrupt_cntxt        = uvma_interrupt_cntxt_c ::type_id::create("interrupt_cntxt"       );
-   debug_cntxt            = uvma_debug_cntxt_c     ::type_id::create("debug_cntxt"           );
-   obi_memory_instr_cntxt = uvma_obi_memory_cntxt_c::type_id::create("obi_memory_instr_cntxt");
-   obi_memory_data_cntxt  = uvma_obi_memory_cntxt_c::type_id::create("obi_memory_data_cntxt" );
-   mem = uvml_mem_c#(32)::type_id::create("mem");
+   clknrst_cntxt          = uvma_clknrst_cntxt_c         ::type_id::create("clknrst_cntxt"         );
+   interrupt_cntxt        = uvma_interrupt_cntxt_c       ::type_id::create("interrupt_cntxt"       );
+   debug_cntxt            = uvma_debug_cntxt_c           ::type_id::create("debug_cntxt"           );
+   obi_memory_instr_cntxt = uvma_obi_memory_cntxt_c      ::type_id::create("obi_memory_instr_cntxt");
+   obi_memory_data_cntxt  = uvma_obi_memory_cntxt_c      ::type_id::create("obi_memory_data_cntxt" );
+   rvfi_cntxt             = uvma_rvfi_cntxt_c#(ILEN,XLEN)::type_id::create("rvfi_cntxt"      );
+   mem                    = uvml_mem_c#(32)              ::type_id::create("mem");
 
    sample_cfg_e   = new("sample_cfg_e"  );
    sample_cntxt_e = new("sample_cntxt_e");

--- a/env/uvme/vseq/uvme_cv32e20_interrupt_noise_vseq.sv
+++ b/env/uvme/vseq/uvme_cv32e20_interrupt_noise_vseq.sv
@@ -114,7 +114,7 @@ class uvme_cv32e20_interrupt_noise_c extends uvme_cv32e20_base_vseq_c;
    extern virtual task rand_delay();
 
    /**
-    * Watches the RVFI instruction retirement interface and triggers wfi_retired_e each
+    * Watches the RVFI instruction retirement interface and puts a token into wfi_sem each
     * time a WFI instruction retires.
     */
    extern virtual task wfi_monitor();

--- a/env/uvme/vseq/uvme_cv32e20_interrupt_noise_vseq.sv
+++ b/env/uvme/vseq/uvme_cv32e20_interrupt_noise_vseq.sv
@@ -19,10 +19,48 @@
 `define __UVME_CV32E20_INTERRUPT_NOISE_SV__
 
 /**
- * Virtual sequence responsible for starting the system clock and issuing
- * the initial reset pulse to the DUT.
+ * Virtual sequence responsible for running a free-running stream of
+ * random interrupt events to the DUT. These events are asynchronous with the main test program.
  */
 class uvme_cv32e20_interrupt_noise_c extends uvme_cv32e20_base_vseq_c;
+
+   // Free-running interrupt noise generation (all three threads below) is only allowed up to
+   // NOISE_CUTOFF_TIME_NS in simulated time; a busy noise stream can otherwise perpetually starve the
+   // core of the chance to drain pending interrupts and return to executing the test program,
+   // potentially causing a livelock on corev_rand_interrupt_nested.
+   //
+   // Past this point:
+   //  - gen_assert/gen_deassert (fire-and-forget UVMA_INTERRUPT_SEQ_ITEM_ACTION_DEASSERT/ASSERT)
+   //    simply stop. UVMA_INTERRUPT_SEQ_ITEM_ACTION_ASSERT (driven by the gen_deassert thread --
+   //    the two are cosmetically mislabeled, see uvma_interrupt_drv.sv) drives a line high and
+   //    releases its tracking semaphore immediately with no self-clear
+   //    (uvma_interrupt_drv_c::assert_irq()); the line only clears via a later DEASSERT lucky
+   //    enough to target the same bit, or the DUT's irq_ack handshake. Left running past the
+   //    cutoff, one of these can leave a line stuck pending indefinitely, which -- combined with
+   //    a WFI-only interrupt-vector handler that does no masking -- produces a self-sustaining
+   //    wfi -> mret -> re-take same still-pending line -> wfi livelock with no forward progress
+   //    (observed on corev_rand_interrupt_exception).
+   //  - gen_assert_until_ack keeps running, but gated one action per real WFI retirement (see
+   //    wfi_monitor()/wait_for_noise_slot() below) instead of being cut off entirely -- a total
+   //    cutoff strands any test whose generated program relies on an interrupt to wake a WFI
+   //    forever asleep (observed as a 100ms watchdog timeout on corev_rand_interrupt_debug).
+   //    This action always self-clears via the real irq_ack handshake
+   //    (uvma_interrupt_drv_c::assert_irq_until_ack()), so it can't leave a line stuck the way
+   //    the other two can.
+   localparam longint unsigned NOISE_CUTOFF_TIME_NS = 10_000_000;
+
+   // WFI instruction encoding (opcode 1110011, funct12 0x105, rs1=rd=x0), used by
+   // wfi_monitor() to detect a WFI retirement over RVFI. This is done to sense the
+   // WFI retirement rather than just the irq_ack handshake.
+   localparam bit [31:0] WFI_INSTR_ENCODING = 32'h10500073;
+
+   // One key is put() by wfi_monitor() each time the core retires a WFI instruction, and
+   // get() by a noise-generation loop past the cutoff before it's allowed to issue its next
+   // action. A semaphore (rather than a plain SV event) is required here: an event trigger
+   // that occurs while no thread is yet parked on it is lost, which would permanently
+   // deadlock the core in WFI the first time the three generator threads' independent
+   // rand_delay()s all happened to still be in flight when the WFI retired.
+   semaphore wfi_sem;
 
    rand int unsigned short_delay_wgt;
    rand int unsigned med_delay_wgt;
@@ -74,11 +112,26 @@ class uvme_cv32e20_interrupt_noise_c extends uvme_cv32e20_base_vseq_c;
     */
    extern virtual task body();
    extern virtual task rand_delay();
+
+   /**
+    * Watches the RVFI instruction retirement interface and triggers wfi_retired_e each
+    * time a WFI instruction retires.
+    */
+   extern virtual task wfi_monitor();
+
+   /**
+    * Called at the top of each gen_assert_until_ack loop iteration (the only noise thread
+    * still running past the cutoff -- see NOISE_CUTOFF_TIME_NS above). Returns immediately
+    * before NOISE_CUTOFF_TIME_NS; after it, blocks until the core retires a WFI.
+    */
+   extern virtual task wait_for_noise_slot();
 endclass : uvme_cv32e20_interrupt_noise_c
 
 function uvme_cv32e20_interrupt_noise_c::new(string name="uvme_cv32e20_interrupt_noise");
 
    super.new(name);
+
+   wfi_sem = new(0);
 
 endfunction : new
 
@@ -94,15 +147,48 @@ task uvme_cv32e20_interrupt_noise_c::rand_delay();
   endcase
 endtask : rand_delay
 
+task uvme_cv32e20_interrupt_noise_c::wfi_monitor();
+  bit               last_order_valid = 0;
+  longint unsigned  last_order;
+
+  forever begin
+    @(cntxt.rvfi_cntxt.instr_vif[0].mon_cb);
+    // rvfi_valid/rvfi_insn hold their last-sampled value rather than pulsing back to an
+    // invalid state, so once the core stops retiring (e.g. genuinely parked in WFI) this
+    // condition would otherwise stay spuriously true on every subsequent clock -- checking
+    // rvfi_order actually advancing is what distinguishes a real new retirement.
+    if (cntxt.rvfi_cntxt.instr_vif[0].mon_cb.rvfi_valid &&
+        (!last_order_valid || cntxt.rvfi_cntxt.instr_vif[0].mon_cb.rvfi_order != last_order)) begin
+      last_order       = cntxt.rvfi_cntxt.instr_vif[0].mon_cb.rvfi_order;
+      last_order_valid = 1;
+      if (cntxt.rvfi_cntxt.instr_vif[0].mon_cb.rvfi_insn == WFI_INSTR_ENCODING) begin
+        wfi_sem.put(1);
+      end
+    end
+  end
+endtask : wfi_monitor
+
+task uvme_cv32e20_interrupt_noise_c::wait_for_noise_slot();
+  if ($time >= NOISE_CUTOFF_TIME_NS) begin
+    wfi_sem.get(1);
+  end
+endtask : wait_for_noise_slot
+
 task uvme_cv32e20_interrupt_noise_c::body();
 
   fork
+    begin : wfi_monitor_thread
+      wfi_monitor();
+    end
+
     begin : gen_assert_until_ack
 
       repeat (initial_delay_assert_until_ack) @(cntxt.interrupt_cntxt.vif.drv_cb);
 
-      while(1) begin
+      while (1) begin
         uvma_interrupt_seq_item_c irq_req;
+
+        wait_for_noise_slot();
 
         `uvm_create_on(irq_req, p_sequencer.interrupt_sequencer);
         start_item(irq_req);
@@ -124,7 +210,7 @@ task uvme_cv32e20_interrupt_noise_c::body();
 
       repeat (initial_delay_assert) @(cntxt.interrupt_cntxt.vif.drv_cb);
 
-      while(1) begin
+      while ($time < NOISE_CUTOFF_TIME_NS) begin
         uvma_interrupt_seq_item_c irq_req;
 
         `uvm_do_on_with(irq_req, p_sequencer.interrupt_sequencer, {
@@ -141,7 +227,7 @@ task uvme_cv32e20_interrupt_noise_c::body();
 
       repeat (initial_delay_deassert) @(cntxt.interrupt_cntxt.vif.drv_cb);
 
-      while(1) begin
+      while ($time < NOISE_CUTOFF_TIME_NS) begin
         uvma_interrupt_seq_item_c irq_req;
 
         `uvm_do_on_with(irq_req, p_sequencer.interrupt_sequencer, {

--- a/mk/uvmt/uvmt.mk
+++ b/mk/uvmt/uvmt.mk
@@ -82,6 +82,7 @@ CFG             ?= default
 GEN_START_INDEX ?= 0
 GEN_NUM_TESTS   ?= 1
 export RUN_INDEX       ?= 0
+OPT_RUN_INDEX_SUFFIX    = _$(RUN_INDEX)
 
 # Common output directories
 SIM_RESULTS             ?= $(if $(CV_RESULTS),$(abspath $(CV_RESULTS))/$(SIMULATOR)_results,$(MAKE_PATH)/$(SIMULATOR)_results)
@@ -103,39 +104,6 @@ EMB_BUILD_ONLY_ARG  = $(if $(filter $(YES_VALS),$(EMB_BUILD_ONLY)),YES,NO)
 EMB_DEBUG_ARG       = $(if $(filter $(YES_VALS),$(EMB_DEBUG)),YES,NO)
 
 # UVM Environment
-# OLD
-#export DV_UVMT_PATH             = $(CV32E20_DV)/$(CV_CORE_LC)/tb/uvmt
-#export DV_UVME_PATH             = $(CV32E20_DV)/$(CV_CORE_LC)/env/uvme
-#export DV_UVML_HRTBT_PATH       = $(CV32E20_DV)/lib/uvm_libs/uvml_hrtbt
-#export DV_UVMA_CORE_CNTRL_PATH  = $(CV32E20_DV)/lib/uvm_agents/uvma_core_cntrl
-#export DV_UVMA_ISACOV_PATH      = $(CV32E20_DV)/lib/uvm_agents/uvma_isacov
-#export DV_UVMA_RVFI_PATH        = $(CV32E20_DV)/lib/uvm_agents/uvma_rvfi
-#export DV_UVMA_RVVI_PATH        = $(CV32E20_DV)/lib/uvm_agents/uvma_rvvi
-#export DV_UVMA_RVVI_OVPSIM_PATH = $(CV32E20_DV)/lib/uvm_agents/uvma_rvvi_ovpsim
-#export DV_UVMA_CLKNRST_PATH     = $(CV32E20_DV)/lib/uvm_agents/uvma_clknrst
-#export DV_UVMA_INTERRUPT_PATH   = $(CV32E20_DV)/lib/uvm_agents/uvma_interrupt
-#export DV_UVMA_DEBUG_PATH       = $(CV32E20_DV)/lib/uvm_agents/uvma_debug
-#export DV_UVMA_PMA_PATH         = $(CV32E20_DV)/lib/uvm_agents/uvma_pma
-#export DV_UVMA_OBI_MEMORY_PATH  = $(CV32E20_DV)/lib/uvm_agents/uvma_obi_memory
-#export DV_UVMA_FENCEI_PATH      = $(CV32E20_DV)/lib/uvm_agents/uvma_fencei
-#export DV_UVML_TRN_PATH         = $(CV32E20_DV)/lib/uvm_libs/uvml_trn
-#export DV_UVML_LOGS_PATH        = $(CV32E20_DV)/lib/uvm_libs/uvml_logs
-#export DV_UVML_SB_PATH          = $(CV32E20_DV)/lib/uvm_libs/uvml_sb
-#export DV_UVML_MEM_PATH         = $(CV32E20_DV)/lib/uvm_libs/uvml_mem
-#
-#export DV_UVMC_RVFI_SCOREBOARD_PATH      = $(CV32E20_DV)/lib/uvm_components/uvmc_rvfi_scoreboard/
-#export DV_UVMC_RVFI_REFERENCE_MODEL_PATH = $(CV32E20_DV)/lib/uvm_components/uvmc_rvfi_reference_model/
-#
-#export DV_OVPM_HOME             = $(CV32E20_DV)/vendor_lib/imperas
-#export DV_OVPM_MODEL            = $(DV_OVPM_HOME)/imperas_DV_COREV
-#
-#export DV_OVPM_DESIGN           = $(DV_OVPM_HOME)/design
-#
-#export DV_SVLIB_PATH            = $(CV32E20_DV)/$(CV_CORE_LC)/vendor_lib/verilab
-#
-#DV_UVMT_SRCS                  = $(wildcard $(DV_UVMT_PATH)/*.sv))
-
-# NEW NEW NEW!!!
 export DV_UVMT_PATH             = $(CV32E20_DV)/tb/uvmt
 export DV_UVME_PATH             = $(CV32E20_DV)/env/uvme
 export DV_UVML_HRTBT_PATH       = $(CV_VERIF_PKG)/lib/uvm_libs/uvml_hrtbt
@@ -172,10 +140,14 @@ DV_UVMT_SRCS                  = $(wildcard $(DV_UVMT_PATH)/*.sv))
 UVM_TEST_NAME ?= uvmt_$(CV_CORE_LC)_general_purpose_test_c
 TEST_UVM_TEST ?= $(UVM_TEST_NAME)
 
+# CORE-V-VERIF
+CV_VERIF_PKG        := $(CV32E20_DV)/vendor_lib/openhwgroup_core-v-verif
+export CV_VERIF_PKG  = $(CV32E20_DV)/vendor_lib/openhwgroup_core-v-verif
+
 # Google's random instruction generator
-RISCVDV_PKG         := $(CV32E20_DV)/$(CV_CORE_LC)/vendor_lib/google/riscv-dv
-COREVDV_PKG         := $(CV32E20_DV)/lib/corev-dv
-CV_CORE_COREVDV_PKG := $(CV32E20_DV)/$(CV_CORE_LC)/env/corev-dv
+RISCVDV_PKG         := $(CV32E20_DV)/vendor_lib/google/riscv-dv
+COREVDV_PKG         := $(CV_VERIF_PKG)/lib/corev-dv
+CV_CORE_COREVDV_PKG := $(CV32E20_DV)/env/corev-dv
 export RISCV_DV_ROOT         = $(RISCVDV_PKG)
 export COREV_DV_ROOT         = $(COREVDV_PKG)
 export CV_CORE_COREV_DV_ROOT = $(CV_CORE_COREVDV_PKG)
@@ -215,12 +187,6 @@ export DESIGN_RTL_DIR = $(CV_CORE_PKG)/rtl
 
 RTLSRC_HOME   := $(CV_CORE_PKG)/rtl
 RTLSRC_INCDIR := $(RTLSRC_HOME)/include
-
-# CORE-V-VERIF
-#CV_VERIF_PKG        := $(CV32E20_DV)/$(CV_CORE_LC)/vendor_lib/openhwgroup_core-v-verif
-#export CV_VERIF_PKG  = $(CV32E20_DV)/$(CV_CORE_LC)/vendor_lib/openhwgroup_core-v-verif
-CV_VERIF_PKG        := $(CV32E20_DV)/vendor_lib/openhwgroup_core-v-verif
-export CV_VERIF_PKG  = $(CV32E20_DV)/vendor_lib/openhwgroup_core-v-verif
 
 # RVVI
 #RVVI_HOME             := $(CV32E20_DV)/$(CV_CORE_LC)/vendor_lib/riscv-verification/RVVI

--- a/sim/ExternalRepos.mk
+++ b/sim/ExternalRepos.mk
@@ -16,11 +16,15 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/MikeOpenHWGroup/cve2
 CV_CORE_BRANCH ?= umode
-CV_CORE_HASH   ?= f217917
+#CV_CORE_HASH   ?= f217917
+CV_CORE_HASH   ?= ed46a40ffd552fc7a0a590b242dcf46c4ee9cf42
 
-CV_VERIF_REPO   ?= https://github.com/openhwgroup/core-v-verif
+#CV_VERIF_REPO   ?= https://github.com/openhwgroup/core-v-verif
+#CV_VERIF_BRANCH ?= cv32e20-dv/dev
+#CV_VERIF_HASH   ?= 6b5a46353bf69baf4f917b9d59c5f0c68a2f529b
+CV_VERIF_REPO   ?= https://github.com/MikeOpenHWGroup/core-v-verif
 CV_VERIF_BRANCH ?= cv32e20-dv/dev
-CV_VERIF_HASH   ?= 6b5a46353bf69baf4f917b9d59c5f0c68a2f529b
+CV_VERIF_HASH   ?= 85e4f4a
 
 RISCVDV_REPO    ?= https://github.com/google/riscv-dv
 RISCVDV_BRANCH  ?= master

--- a/tb/uvmt/uvmt_cv32e20_dut_wrap.sv
+++ b/tb/uvmt/uvmt_cv32e20_dut_wrap.sv
@@ -86,6 +86,8 @@ module uvmt_cv32e20_dut_wrap #(
     assign debug_if.clk      = clknrst_if.clk;
     assign debug_if.reset_n  = clknrst_if.reset_n;
     assign debug_req_uvma    = debug_if.debug_req;
+    // FIXME: need a sol'nn that does not require probing the core RTL.
+    assign debug_if.id_in_ready = cv32e20_top_i.u_cve2_top.u_cve2_core.id_stage_i.controller_i.id_in_ready_o;
 
     assign debug_req = debug_req_vp | debug_req_uvma;
 
@@ -103,6 +105,8 @@ module uvmt_cv32e20_dut_wrap #(
     assign interrupt_if.irq_id                  = cv32e20_top_i.u_cve2_top.u_cve2_core.id_stage_i.controller_i.exc_cause_o[4:0]; //irq_id;
 //    assign interrupt_if.irq_ack                 = cv32e20_top_i.u_cve2_top.u_cve2_core.id_stage_i.controller_i.handle_irq; //irq_ack;
     assign interrupt_if.irq_ack                 = (cv32e20_top_i.u_cve2_top.u_cve2_core.id_stage_i.controller_i.ctrl_fsm_cs == 4'h7);//irq_ack
+    // FIXME: need a sol'nn that does not require probing the core RTL.
+    assign interrupt_if.id_in_ready             = cv32e20_top_i.u_cve2_top.u_cve2_core.id_stage_i.controller_i.id_in_ready_o;
 
     assign vp_interrupt_if.clk                  = clknrst_if.clk;
     assign vp_interrupt_if.reset_n              = clknrst_if.reset_n;
@@ -111,6 +115,8 @@ module uvmt_cv32e20_dut_wrap #(
     // was vp_interrupt_if.irq;
     assign vp_interrupt_if.irq_id               = cv32e20_top_i.u_cve2_top.u_cve2_core.id_stage_i.controller_i.exc_cause_o[4:0];    //irq_id;
     assign vp_interrupt_if.irq_ack              = (cv32e20_top_i.u_cve2_top.u_cve2_core.id_stage_i.controller_i.ctrl_fsm_cs == 4'h7);//irq_ack
+    // FIXME: need a sol'nn that does not require probing the core RTL.
+    assign vp_interrupt_if.id_in_ready          = cv32e20_top_i.u_cve2_top.u_cve2_core.id_stage_i.controller_i.id_in_ready_o;
 
     assign irq = irq_uvma | irq_vp;
 

--- a/tb/uvmt/uvmt_cv32e20_dut_wrap.sv
+++ b/tb/uvmt/uvmt_cv32e20_dut_wrap.sv
@@ -86,7 +86,7 @@ module uvmt_cv32e20_dut_wrap #(
     assign debug_if.clk      = clknrst_if.clk;
     assign debug_if.reset_n  = clknrst_if.reset_n;
     assign debug_req_uvma    = debug_if.debug_req;
-    // FIXME: need a sol'nn that does not require probing the core RTL.
+    // FIXME: need a sol'n that does not require probing the core RTL.
     assign debug_if.id_in_ready = cv32e20_top_i.u_cve2_top.u_cve2_core.id_stage_i.controller_i.id_in_ready_o;
 
     assign debug_req = debug_req_vp | debug_req_uvma;
@@ -105,7 +105,7 @@ module uvmt_cv32e20_dut_wrap #(
     assign interrupt_if.irq_id                  = cv32e20_top_i.u_cve2_top.u_cve2_core.id_stage_i.controller_i.exc_cause_o[4:0]; //irq_id;
 //    assign interrupt_if.irq_ack                 = cv32e20_top_i.u_cve2_top.u_cve2_core.id_stage_i.controller_i.handle_irq; //irq_ack;
     assign interrupt_if.irq_ack                 = (cv32e20_top_i.u_cve2_top.u_cve2_core.id_stage_i.controller_i.ctrl_fsm_cs == 4'h7);//irq_ack
-    // FIXME: need a sol'nn that does not require probing the core RTL.
+    // FIXME: need a sol'n that does not require probing the core RTL.
     assign interrupt_if.id_in_ready             = cv32e20_top_i.u_cve2_top.u_cve2_core.id_stage_i.controller_i.id_in_ready_o;
 
     assign vp_interrupt_if.clk                  = clknrst_if.clk;
@@ -115,7 +115,7 @@ module uvmt_cv32e20_dut_wrap #(
     // was vp_interrupt_if.irq;
     assign vp_interrupt_if.irq_id               = cv32e20_top_i.u_cve2_top.u_cve2_core.id_stage_i.controller_i.exc_cause_o[4:0];    //irq_id;
     assign vp_interrupt_if.irq_ack              = (cv32e20_top_i.u_cve2_top.u_cve2_core.id_stage_i.controller_i.ctrl_fsm_cs == 4'h7);//irq_ack
-    // FIXME: need a sol'nn that does not require probing the core RTL.
+    // FIXME: need a sol'n that does not require probing the core RTL.
     assign vp_interrupt_if.id_in_ready          = cv32e20_top_i.u_cve2_top.u_cve2_core.id_stage_i.controller_i.id_in_ready_o;
 
     assign irq = irq_uvma | irq_vp;

--- a/tests/programs/custom/README.md
+++ b/tests/programs/custom/README.md
@@ -220,7 +220,7 @@ PASSED** on the core TB. `misalign.c` is the ONLY test with this pattern
 (swept all C/.h/.S; dhrystone's `UNALIGNED` macro is the standard newlib guard,
 not a hazard).
 
-## `bin/run_c_tests.py` — multi-TB C test runner (DONE, committed "Add simple regress script")
+## `bin/run_tests.py` — multi-TB test runner (DONE, committed "Add simple regress script"; renamed from `run_c_tests.py`)
 
 Runs the cleaned-up C test-programs and prints a pass/fail summary; exit 0 only
 if all selected tests PASS (CI-gate friendly). Paths resolve relative to the
@@ -248,8 +248,10 @@ The default `TESTS` list (13) all PASS on **core** (full run, rc=0). On
 12 were not exhaustively run on uvmt yet. Parked set (`riscv_csr` + 5
 `debug_test*` variants) is opt-in via `--include-parked`.
 
-Open question raised, not yet decided: filename `run_c_tests.py` is now a bit
-narrow since it drives both testbenches — possible rename to `run_tests.py`.
+Resolved: renamed `run_c_tests.py` → `run_tests.py`, since it drives both C
+and assembly tests. Also added `--corev-dv-only` (run just COREV_DV_TESTS,
+nothing else) and an automatic one-time `make corev-dv` setup step, run
+before any corev-dv test builds whenever the selected set includes one.
 
 ## Assembly test-program cleanup (DONE this session)
 
@@ -291,16 +293,15 @@ self-checking ones (4 asm + arith_0/1 vacuous) pass on core. uvmt+ISS
 verification of the step-compare tests and the parked debug/`riscv_csr` work
 (#10/#11) is deferred.
 
-`bin/run_c_tests.py` updated: new `ASM_TESTS` group (`load_store_rs1_zero`,
-`illegal_instr_test`, `generic_exception_test`, `csr_instr_asm`) folded into the
-default core selection (`TESTS = C_TESTS + ASM_TESTS`); step-compare arith/CSR
-and debug variants moved/added under `PARKED` (`--include-parked`, intended for
-`--tb uvmt`). The `_c_` in the filename is now narrow — rename to `run_tests.py`
-still open.
+`bin/run_tests.py` (then still `run_c_tests.py`) updated: new `ASM_TESTS` group
+(`load_store_rs1_zero`, `illegal_instr_test`, `generic_exception_test`,
+`csr_instr_asm`) folded into the default core selection
+(`TESTS = C_TESTS + ASM_TESTS`); step-compare arith/CSR and debug variants
+moved/added under `PARKED` (`--include-parked`, intended for `--tb uvmt`).
 
 **Resume checklist (next session):**
 1. uvmt+ISS verification of the step-compare tests (deferred this pass):
-   `python3 bin/run_c_tests.py --tb uvmt riscv_arithmetic_basic_test_0
+   `python3 bin/run_tests.py --tb uvmt riscv_arithmetic_basic_test_0
    riscv_arithmetic_basic_test_1 csr_instr_asm` (sets `SIMULATOR=dsim`). These
    pass vacuously on core; the meaningful check is the RVFI-vs-Spike compare.
 2. Debug variants under uvmt with their plusargs (task #11): `debug_test_reset`
@@ -310,10 +311,10 @@ still open.
    never entered there.
 3. `riscv_csr` M-only counter-CSR reconciliation (task #10 — see "Parked work"
    section above), then uvmt+ISS.
-4. Decide the `run_c_tests.py` → `run_tests.py` rename.
+4. ~~Decide the `run_c_tests.py` → `run_tests.py` rename.~~ Done.
 
 All edits from this session are in the working tree only (no commits): touched
-`bsp/cv32e20_dv.h`, `bin/run_c_tests.py`, this README, and under
+`bsp/cv32e20_dv.h`, `bin/run_tests.py` (then `run_c_tests.py`), this README, and under
 `tests/programs/custom/`: `load_store_rs1_zero/load_store_rs1_zero.S`,
 `illegal_instr_test/illegal_instr_test.S`,
 `generic_exception_test/generic_exception_test.S`, `csr_instr_asm/csr_instr_asm.S`,


### PR DESCRIPTION
## Description
The goal of this PR is to (mostly) restore the 'corev-dv' pseudo-random test-program generation to the UVM environment.

## Changes
1. The usual updates to address bit-rot and a new simulator (Questasim vsim 2025.3_2)
2. Updates to the used of the debug and interrupt agents to adapt to CVE2 (note: these agents are cloned from [core-v-verif](https://github.com/openhwgroup/core-v-verif/tree/cv32e20-dv/dev/lib/uvm_agents), they are not resident in this repo.)
3. Fixed end-of-test signalling.
4. Renamed `bin/run_c_tests.py` to `bin/run_tests.py` (because it can run all test types now, not just C test-programs.

## Verification
Check out `bin/run_tests.py` for instructions for running these tests.

## ToDo
Several corev-dv tests are not generating or running correctly at this time.  I will either push fixes into this PR, or create a new PR as these get fixed.