### PR TITLE
tb(mm_ram): platform register reads zeros, gate mtime increment on wr…

### DIFF
--- a/tb/core/mm_ram.sv
+++ b/tb/core/mm_ram.sv
@@ -505,8 +505,9 @@ module mm_ram
                     select_rdata_d = CLINT;
                     clint_rdata_d  = SIG_VERSION_VAL;
                 end else if (data_addr_i == MMADDR_SIG_PLATFORM) begin
+                    // platform register reads as zeros
                     select_rdata_d = CLINT;
-                    clint_rdata_d  = 32'(sig_platform_q);
+                    clint_rdata_d  = '0;
                 end else
                     select_rdata_d = ERR;
 
@@ -600,8 +601,13 @@ module mm_ram
             mtime_q    <= '0;
             mtimecmp_q <= '1;
         end else begin
-            mtime_q[31:0]  <= mtime_we_lo  ? clint_wdata : mtime_next[31:0];
-            mtime_q[63:32] <= mtime_we_hi  ? clint_wdata : mtime_next[63:32];
+            // writes suppress the increment (no carry into the written half)
+            if (mtime_we_lo || mtime_we_hi) begin
+                if (mtime_we_lo) mtime_q[31:0]  <= clint_wdata;
+                if (mtime_we_hi) mtime_q[63:32] <= clint_wdata;
+            end else begin
+                mtime_q <= mtime_next;
+            end
             if (mtimecmp_we_lo) mtimecmp_q[31:0]  <= clint_wdata;
             if (mtimecmp_we_hi) mtimecmp_q[63:32] <= clint_wdata;
         end


### PR DESCRIPTION
During review of https://github.com/openhwgroup/cv32e40s-dv/pull/5 copilot flagged bugs that are present across cores that exercise ACTs. Note that these issues are not affecting any tests currently.

- mtime_q was updated as mtime_we ? wdata : mtime_next per 32-bit half. On a write to only one half, the other half  still took mtime_next, which can absorb a carry out of the old value of the written half
- Saill returns zeros for read unconditionally



