### PR TITLE
Fixes to close code coverage

### DIFF
--- a/bin/run_tests.py
+++ b/bin/run_tests.py
@@ -52,7 +52,8 @@ PATH, as for a normal `make test`.
     bin/run_tests.py
     python3 bin/run_tests.py                    # equivalent
 
-    # Run the same set on the UVM testbench (vsim):
+    # Run the same set on the UVM testbench (vsim), plus UVMT_TESTS (directed
+    # tests that only make sense under uvmt, e.g. nmi_test):
     bin/run_tests.py --tb uvmt
     # (equivalent to `make test TEST=<name> SIMULATOR=vsim` per test; the
     #  script sets SIMULATOR=vsim for you, so no need to export it yourself.)
@@ -84,6 +85,10 @@ PATH, as for a normal `make test`.
     bin/run_tests.py --tb uvmt --gen-seed 363891135 --run-seed 354410829 \
         corev_rand_instr_and_data_stalls
 
+    # Collect code coverage (uvmt only; equivalent to `make test ... COV=1`
+    # per test -- see docs/COVERAGE-MAKE-TARGETS.md for the report targets):
+    bin/run_tests.py --tb uvmt --cov hello-world
+
     # Other options:
     #   --cfg NAME      uvmt config subdirectory                (default: default)
     #   --run-index N   RUN_INDEX subdirectory                  (default: 0)
@@ -91,6 +96,7 @@ PATH, as for a normal `make test`.
     #   --run-seed SEED test-step SEED ('random' or a literal value)
     #   --timeout SECS  per-test timeout                        (default: 1800)
     #   --jobs N, -j N  run up to N tests concurrently           (default: 1)
+    #   --cov           collect code coverage (uvmt only)
     #   --quiet         suppress per-test simulation banners
     #   -h / --help     full option help
 
@@ -110,7 +116,11 @@ With --jobs > 1 and --tb uvmt, this script instead compiles the design ONCE
 up front (`make comp`, serialized, in addition to the existing one-time `make
 corev-dv` setup for corev-dv tests) and then passes COMP=NO to every test in
 the parallel batch, so workers only run `vsim` against the already-compiled
-design -- each in its own per-test/run-index run directory
+design. If --cov is also given, that one-time compile is done with COV=1 too
+(otherwise the shared design has no +cover instrumentation and every
+worker's .ucdb ends up with assertions/covergroups but zero statement/
+branch/condition coverage, since COMP=NO skips each worker's own vopt) --
+each worker runs in its own per-test/run-index run directory
 (sim/uvmt/vsim_results/<cfg>/<test>/<run_index>/), which `make`'s `run`
 target `vmap`s back to the shared read-only compiled library. Many `vsim`
 processes reading one compiled snapshot concurrently is a standard, safe
@@ -184,7 +194,7 @@ C_TESTS = [
     "branch_zero",
     "coremark",
     "dhrystone",
-    "all_csr_por",
+#    "all_csr_por",
     "csr_instructions",
     "hpmcounter_basic_test",
     "illegal",
@@ -228,6 +238,17 @@ PARKED = [
     "debug_test_reset",
     "debug_test_known_miscompares",
     "debug_test_trigger",
+]
+
+# Directed tests that are part of the standard regression (unlike PARKED,
+# not opt-in) but only make sense on the uvmt TB, since they need uvmt-only
+# stimulus with no core-TB equivalent. Automatically added to the default
+# selection whenever --tb uvmt is chosen (see main()); ignored for --tb core.
+#   * nmi_test needs the uvmt interrupt-agent's +nmi_assert stimulus (see
+#     uvme_cv32e20_nmi_assert_vseq.sv); on the core TB the NMI line is never
+#     asserted.
+UVMT_TESTS = [
+    "nmi_test",
 ]
 
 # corev-dv (OpenHW's class extensions of Google's riscv-dv) generated regression
@@ -363,14 +384,22 @@ def setup_corev_dv(tb, timeout):
                   "no corev-dv test can build without it")
 
 
-def setup_comp(tb, timeout):
+def setup_comp(tb, timeout, cov=False):
     """Run `make comp` once: compiles the main testbench (uvmt_*_tb_vopt) into
     the shared work library. Required before a --jobs > 1 batch can safely
     pass COMP=NO to its workers -- without a compiled design already sitting
     in the shared library, every worker would either fail (nothing to run
-    against) or race to compile it themselves. Aborts the script on failure."""
+    against) or race to compile it themselves. Aborts the script on failure.
+
+    cov: pass COV=1 to this compile so vopt instruments the design with
+    +cover -- required when the --jobs > 1 batch will also run with --cov,
+    since workers pass COMP=NO and reuse this shared compile as-is (without
+    this, every worker's .ucdb ends up with no statement/branch/condition
+    coverage at all, only assertions/covergroups)."""
     tbcfg = TESTBENCHES[tb]
     cmd = ["make", "comp"] + tbcfg["make_args"]
+    if cov:
+        cmd.append("COV=1")
     env = make_env(tbcfg)
 
     print(f"[Setup/{tb}] make comp (one-time compile for --jobs > 1) ...")
@@ -387,7 +416,7 @@ def setup_comp(tb, timeout):
 
 
 def run_test(tb, test, run_index, cfg, timeout, quiet, extra_make_args=None,
-             label=None, gen_seed="random", run_seed="random"):
+             label=None, gen_seed="random", run_seed="random", cov=False):
     """Build+run one test on the chosen testbench; return
     (outcome, detail, gen_seed_used, run_seed_used).
 
@@ -411,6 +440,12 @@ def run_test(tb, test, run_index, cfg, timeout, quiet, extra_make_args=None,
     extra_make_args: additional make variable assignments appended to each
     command line (e.g. ["COMP=NO"] for a --jobs > 1 batch that already had
     setup_comp() run once beforehand).
+    cov: pass COV=1 to the actual firmware build+run (equivalent to `make
+    test ... COV=1`), so vopt instruments the design and Questa writes a
+    .ucdb -- see docs/COVERAGE-MAKE-TARGETS.md for the report targets that
+    consume it. Deliberately NOT passed to the gen_corev-dv step above: that's
+    a separate UVM environment/vsim invocation (the random-program generator,
+    unrelated to the DUT), so instrumenting it would be pointless.
     label: when set (--jobs > 1), prefixes each printed banner line with the
     test name so concurrent workers' output stays distinguishable; printing
     is done as one locked block per test so lines from different tests can't
@@ -453,6 +488,8 @@ def run_test(tb, test, run_index, cfg, timeout, quiet, extra_make_args=None,
     cmd = ["make", "test", f"TEST={test}", f"RUN_INDEX={run_index}"]
     if test in COREV_DV_TESTS:
         cmd.append(f"SEED={run_seed}")
+    if cov:
+        cmd.append("COV=1")
     cmd += tbcfg["make_args"]
     if extra_make_args:
         cmd += extra_make_args
@@ -553,6 +590,13 @@ def main():
                          "env-level randomization, e.g. OBI stall knobs). "
                          "'random' (default) or a literal value to replay a "
                          "specific prior run. No effect on non-corev-dv tests.")
+    ap.add_argument("--cov", action="store_true",
+                    help="collect code coverage (uvmt only; equivalent to "
+                         "`make test ... COV=1` per test). Requires "
+                         "sim/tools/vsim/cov.tcl to exist, or Questa silently "
+                         "collects nothing -- see docs/COVERAGE-MAKE-TARGETS.md "
+                         "for the report targets (cov, cov_txt, cov_holes, "
+                         "cov_holes_details) that consume the resulting .ucdb.")
     ap.add_argument("--quiet", action="store_true",
                     help="suppress per-test simulation banner output")
     ap.add_argument("--jobs", "-j", type=int, default=1,
@@ -564,6 +608,10 @@ def main():
     if args.jobs < 1:
         ap.error("--jobs must be >= 1")
 
+    if args.cov and args.tb != "uvmt":
+        ap.error("--cov requires --tb uvmt (Questa coverage; the core "
+                  "Verilator testbench has no COV support)")
+
     if args.corev_dv_only:
         if args.tests or args.include_parked or args.include_corev_dv:
             ap.error("--corev-dv-only cannot be combined with test names, "
@@ -573,6 +621,8 @@ def main():
         selected = args.tests
     else:
         selected = list(TESTS)
+        if args.tb == "uvmt":
+            selected += UVMT_TESTS
         if args.include_parked:
             selected += PARKED
         if args.include_corev_dv:
@@ -595,7 +645,7 @@ def main():
             # COMP=NO and safely skip recompilation instead of racing on the
             # shared vsim work library -- see the "Concurrency" section of
             # --help for the full explanation.
-            setup_comp(args.tb, args.timeout)
+            setup_comp(args.tb, args.timeout, cov=args.cov)
             extra_make_args = ["COMP=NO"]
         else:
             print(f"warning: --jobs {args.jobs} with --tb core has not been "
@@ -616,7 +666,8 @@ def main():
                 args.timeout, args.quiet,
                 extra_make_args=extra_make_args,
                 label=test if args.jobs > 1 else None,
-                gen_seed=args.gen_seed, run_seed=args.run_seed)
+                gen_seed=args.gen_seed, run_seed=args.run_seed,
+                cov=args.cov)
         if args.jobs > 1:
             done = "Parsed" if args.parse_only else "Done"
             with _print_lock:

--- a/bsp/handlers.S
+++ b/bsp/handlers.S
@@ -136,7 +136,54 @@ m_fast15_irq_handler:
 	j __no_irq_handler
 
 m_nmi_irq_handler:
-	j __no_irq_handler
+	/* Real NMI handler (unlike the other *_irq_handler stubs above, which
+	   just loop forever): saves all caller-saved regs (NMI can interrupt
+	   arbitrary code, same reasoning as u_sw_irq_handler below), logs
+	   entry, increments nmi_count so a test can positively confirm the
+	   NMI was taken and handled (not just silently missed), and mrets.
+	   NMI exit is a plain mret, same as any other M-mode exception return
+	   -- see cve2_controller.sv, nmi_mode_q is cleared on mret. */
+	addi sp,sp,-64
+	sw ra, 0(sp)
+	sw a0, 4(sp)
+	sw a1, 8(sp)
+	sw a2, 12(sp)
+	sw a3, 16(sp)
+	sw a4, 20(sp)
+	sw a5, 24(sp)
+	sw a6, 28(sp)
+	sw a7, 32(sp)
+	sw t0, 36(sp)
+	sw t1, 40(sp)
+	sw t2, 44(sp)
+	sw t3, 48(sp)
+	sw t4, 52(sp)
+	sw t5, 56(sp)
+	sw t6, 60(sp)
+	la a0, nmi_msg
+	jal ra, puts
+	la t0, nmi_count
+	lw t1, 0(t0)
+	addi t1, t1, 1
+	sw t1, 0(t0)
+	lw ra, 0(sp)
+	lw a0, 4(sp)
+	lw a1, 8(sp)
+	lw a2, 12(sp)
+	lw a3, 16(sp)
+	lw a4, 20(sp)
+	lw a5, 24(sp)
+	lw a6, 28(sp)
+	lw a7, 32(sp)
+	lw t0, 36(sp)
+	lw t1, 40(sp)
+	lw t2, 44(sp)
+	lw t3, 48(sp)
+	lw t4, 52(sp)
+	lw t5, 56(sp)
+	lw t6, 60(sp)
+	addi sp,sp,64
+	mret
 
 u_sw_irq_handler:
 	/* While we are still using puts in handlers, save all caller saved
@@ -232,3 +279,15 @@ unknown_msg:
 	.string "CV32E20 BSP: unknown exception handler entered\n"
 no_exception_handler_msg:
 	.string "CV32E20 BSP: no exception handler installed\n"
+nmi_msg:
+	.string "CV32E20 BSP: NMI handler entered\n"
+
+/* Incremented by m_nmi_irq_handler each time it's entered. Always present
+   (zero-initialized, .bss) so any test can read it via
+   `extern volatile uint32_t nmi_count;` to positively confirm an NMI was
+   taken and handled, without every test needing to define it. */
+.section .bss
+.global nmi_count
+.align 2
+nmi_count:
+	.word 0

--- a/env/corev-dv/target/cv32e20/riscv_core_setting.sv
+++ b/env/corev-dv/target/cv32e20/riscv_core_setting.sv
@@ -36,7 +36,14 @@ riscv_instr_name_t unsupported_instr[];
 riscv_instr_group_t supported_isa[$] = {RV32I, RV32M, RV32C};
 
 // Interrupt mode support
-mtvec_mode_t supported_interrupt_mode[$] = {DIRECT, VECTORED};
+// CV32E20's mtvec.MODE field is hardwired/read-only to 2'b01 (vectored) -
+// see the CV32E20 User Manual (cs_registers.rst: "MODE: Always set to
+// 2'b01 ... (read-only)"). DIRECT must not be offered here: if the
+// generator picks DIRECT, it emits a single flat mtvec_handler that
+// assumes every trap enters at its first instruction, but the hardware
+// still vectors interrupts to mtvec_base + 4*cause, landing mid-prologue
+// and corrupting the register-save context.
+mtvec_mode_t supported_interrupt_mode[$] = {VECTORED};
 
 // The number of interrupt vectors to be generated, only used if VECTORED interrupt mode is
 // supported
@@ -98,11 +105,7 @@ parameter int NUM_HARTS = 1;
 // ----------------------------------------------------------------------------
 
 // Implemented previlieged CSR list
-`ifdef DSIM
-privileged_reg_t implemented_csr[] = {
-`else
 const privileged_reg_t implemented_csr[] = {
-`endif
     // Machine mode mode CSR
     MVENDORID,  // Vendor ID
     MARCHID,    // Architecture ID
@@ -120,9 +123,7 @@ const privileged_reg_t implemented_csr[] = {
     MIP         // Machine interrupt pending
 };
 
-`ifdef DSIM
-  bit [11:0] custom_csr[] = {
-`elsif _VCP
+`ifdef _VCP
   bit [11:0] custom_csr[] = {
 `else
   const bit [11:0] custom_csr[] = {
@@ -133,21 +134,13 @@ const privileged_reg_t implemented_csr[] = {
 // Supported interrupt/exception setting, used for functional coverage
 // ----------------------------------------------------------------------------
 
-`ifdef DSIM
-interrupt_cause_t implemented_interrupt[] = {
-`else
 const interrupt_cause_t implemented_interrupt[] = {
-`endif
     M_SOFTWARE_INTR,
     M_TIMER_INTR,
     M_EXTERNAL_INTR
 };
 
-`ifdef DSIM
-exception_cause_t implemented_exception[] = {
-`else
 const exception_cause_t implemented_exception[] = {
-`endif
     INSTRUCTION_ACCESS_FAULT,
     ILLEGAL_INSTRUCTION,
     BREAKPOINT,

--- a/env/uvme/uvme_cv32e20_cfg.sv
+++ b/env/uvme/uvme_cv32e20_cfg.sv
@@ -133,7 +133,7 @@ constraint cve2_riscv_cons {
       pmp_supported          == 0;
       debug_supported        == 1;
 
-      unaligned_access_supported     == 0;
+      unaligned_access_supported     == 1;
       unaligned_access_amo_supported == 0;
 
       bitmanip_version        == BITMANIP_VERSION_1P00;

--- a/env/uvme/uvme_cv32e20_pkg.sv
+++ b/env/uvme/uvme_cv32e20_pkg.sv
@@ -73,6 +73,7 @@ package uvme_cv32e20_pkg;
    `include "uvme_cv32e20_base_vseq.sv"
    `include "uvme_cv32e20_reset_vseq.sv"
    `include "uvme_cv32e20_interrupt_noise_vseq.sv"
+   `include "uvme_cv32e20_nmi_assert_vseq.sv"
    `include "uvme_cv32e20_core_cntrl_base_seq.sv"
    `include "uvme_cv32e20_core_cntrl_fetch_vseq.sv"
    `include "uvme_cv32e20_vp_debug_control_seq.sv"

--- a/env/uvme/vseq/uvme_cv32e20_interrupt_noise_vseq.sv
+++ b/env/uvme/vseq/uvme_cv32e20_interrupt_noise_vseq.sv
@@ -39,15 +39,38 @@ class uvme_cv32e20_interrupt_noise_c extends uvme_cv32e20_base_vseq_c;
    //    cutoff, one of these can leave a line stuck pending indefinitely, which -- combined with
    //    a WFI-only interrupt-vector handler that does no masking -- produces a self-sustaining
    //    wfi -> mret -> re-take same still-pending line -> wfi livelock with no forward progress
-   //    (observed on corev_rand_interrupt_exception).
+   //    (observed on corev_rand_interrupt_exception), or -- with no WFI involved at all -- an
+   //    endless mret -> re-take -> mret loop on whatever cause that stuck bit maps to,
+   //    observed as a 100ms watchdog timeout on corev_rand_interrupt (mcause 0x80000016,
+   //    fast irq 6, stuck asserted with zero WFI retirements in the whole run). body() now
+   //    forces a final DEASSERT of every non-reserved line once both fire-and-forget threads
+   //    stop, so no bit can be left stuck past the cutoff -- see the comment at that call site.
    //  - gen_assert_until_ack keeps running, but gated one action per real WFI retirement (see
    //    wfi_monitor()/wait_for_noise_slot() below) instead of being cut off entirely -- a total
    //    cutoff strands any test whose generated program relies on an interrupt to wake a WFI
    //    forever asleep (observed as a 100ms watchdog timeout on corev_rand_interrupt_debug).
-   //    This action always self-clears via the real irq_ack handshake
-   //    (uvma_interrupt_drv_c::assert_irq_until_ack()), so it can't leave a line stuck the way
-   //    the other two can.
+   //    This action self-clears via the real irq_ack handshake
+   //    (uvma_interrupt_drv_c::assert_irq_until_ack()) -- *if* the DUT ever takes that specific
+   //    cause. If the generated test program's own CSR content permanently masks a cause off in
+   //    mie, the DUT never acks it, and assert_irq_until_ack() blocks forever holding that
+   //    index's semaphore -- every later request that includes that bit is silently dropped (see
+   //    "already in flight" in uvma_interrupt_drv_c::assert_irq_until_ack()). That's harmless as
+   //    long as some other, live bit is also in the same request, but once enough bits go stuck
+   //    this way, a request drawn entirely from stuck bits is a total no-op: no new edge is ever
+   //    driven, and since this is gated one-per-WFI with no other noise source running, the core
+   //    can be left asleep in WFI forever (observed as a 100ms watchdog timeout on
+   //    corev_rand_interrupt_wfi_mem_stress -- traced live via a temporary $display in
+   //    assert_irq_until_ack(): two bits went permanently un-acked within the first 70us of a
+   //    100ms run, and ~55ms later a request happened to draw only those two). ack_monitor()
+   //    below tracks per-bit ack latency and gen_assert_until_ack excludes any bit that's been
+   //    outstanding too long from future draws, so a stuck bit can no longer poison the pool.
    localparam longint unsigned NOISE_CUTOFF_TIME_NS = 10_000_000;
+
+   // How long a requested bit is allowed to sit un-acked before gen_assert_until_ack treats it
+   // as permanently stuck (e.g. masked off in mie for the rest of the test) and stops selecting
+   // it. Normal acks in practice land within a few hundred to a couple thousand ns; this is
+   // generous enough to never mistake a merely-slow ack for a stuck one.
+   localparam longint unsigned ACK_STUCK_TIMEOUT_NS = 50_000;
 
    // WFI instruction encoding (opcode 1110011, funct12 0x105, rs1=rd=x0), used by
    // wfi_monitor() to detect a WFI retirement over RVFI. This is done to sense the
@@ -62,6 +85,12 @@ class uvme_cv32e20_interrupt_noise_c extends uvme_cv32e20_base_vseq_c;
    // rand_delay()s all happened to still be in flight when the WFI retired.
    semaphore wfi_sem;
 
+   // Per-bit ack tracking for gen_assert_until_ack, maintained by ack_monitor(). A bit is
+   // "outstanding" from the moment gen_assert_until_ack requests it until either a matching
+   // irq_ack/irq_id is observed (cleared) or ACK_STUCK_TIMEOUT_NS elapses (treated as stuck).
+   bit               outstanding_until_ack[32];
+   time              outstanding_until_ack_since[32];
+
    rand int unsigned short_delay_wgt;
    rand int unsigned med_delay_wgt;
    rand int unsigned long_delay_wgt;
@@ -73,6 +102,16 @@ class uvme_cv32e20_interrupt_noise_c extends uvme_cv32e20_base_vseq_c;
 
    `uvm_object_utils_begin(uvme_cv32e20_interrupt_noise_c)
    `uvm_object_utils_end
+
+   // Bit 0 == irq_uvma[0] == NMI (uvmt_cv32e20_dut_wrap.sv irq_nm_i). Not
+   // excluded from noise generation by default -- soft, so any caller's
+   // explicit override (e.g. uvmt_cv32e20_general_purpose_test_c::irq_noise(),
+   // which already pins reserved_irq_mask == 32'h0) still wins outright.
+   // This just guarantees the permissive default is a property of the class
+   // itself, not an accident of the one caller that happens to set it today.
+   constraint reserved_irq_mask_default_c {
+     soft reserved_irq_mask[0] == 1'b0;
+   }
 
    constraint default_delay_c {
      soft short_delay_wgt == 2;
@@ -125,6 +164,20 @@ class uvme_cv32e20_interrupt_noise_c extends uvme_cv32e20_base_vseq_c;
     * before NOISE_CUTOFF_TIME_NS; after it, blocks until the core retires a WFI.
     */
    extern virtual task wait_for_noise_slot();
+
+   /**
+    * Watches irq_ack/irq_id and clears outstanding_until_ack[] on each ack, so
+    * get_stuck_until_ack_mask() can tell a bit that's genuinely still in flight from one that's
+    * merely been requested before and never touched since.
+    */
+   extern virtual task ack_monitor();
+
+   /**
+    * Returns the set of bits currently in outstanding_until_ack[] that have been waiting longer
+    * than ACK_STUCK_TIMEOUT_NS -- i.e. bits gen_assert_until_ack should stop selecting because
+    * the DUT is never going to ack them again.
+    */
+   extern virtual function bit [31:0] get_stuck_until_ack_mask();
 endclass : uvme_cv32e20_interrupt_noise_c
 
 function uvme_cv32e20_interrupt_noise_c::new(string name="uvme_cv32e20_interrupt_noise");
@@ -174,11 +227,37 @@ task uvme_cv32e20_interrupt_noise_c::wait_for_noise_slot();
   end
 endtask : wait_for_noise_slot
 
+task uvme_cv32e20_interrupt_noise_c::ack_monitor();
+  forever begin
+    @(cntxt.interrupt_cntxt.vif.mon_cb);
+    if (cntxt.interrupt_cntxt.vif.mon_cb.irq_ack) begin
+      outstanding_until_ack[cntxt.interrupt_cntxt.vif.mon_cb.irq_id] = 0;
+    end
+  end
+endtask : ack_monitor
+
+function bit [31:0] uvme_cv32e20_interrupt_noise_c::get_stuck_until_ack_mask();
+  bit [31:0] stuck_mask = '0;
+
+  foreach (outstanding_until_ack[i]) begin
+    if (outstanding_until_ack[i] &&
+        (($time - outstanding_until_ack_since[i]) > ACK_STUCK_TIMEOUT_NS)) begin
+      stuck_mask[i] = 1;
+    end
+  end
+
+  return stuck_mask;
+endfunction : get_stuck_until_ack_mask
+
 task uvme_cv32e20_interrupt_noise_c::body();
 
   fork
     begin : wfi_monitor_thread
       wfi_monitor();
+    end
+
+    begin : ack_monitor_thread
+      ack_monitor();
     end
 
     begin : gen_assert_until_ack
@@ -187,8 +266,11 @@ task uvme_cv32e20_interrupt_noise_c::body();
 
       while (1) begin
         uvma_interrupt_seq_item_c irq_req;
+        bit [31:0]                stuck_mask;
 
         wait_for_noise_slot();
+
+        stuck_mask = get_stuck_until_ack_mask();
 
         `uvm_create_on(irq_req, p_sequencer.interrupt_sequencer);
         start_item(irq_req);
@@ -198,45 +280,100 @@ task uvme_cv32e20_interrupt_noise_c::body();
           repeat_count dist { 1 :/ 9, [2:3] :/ 1 };
 
           (irq_mask & local::reserved_irq_mask) == 0;
+          (irq_mask & local::stuck_mask) == 0;
         });
         finish_item(irq_req);
 
-        rand_delay();
-
-      end
-    end
-
-    begin : gen_assert
-
-      repeat (initial_delay_assert) @(cntxt.interrupt_cntxt.vif.drv_cb);
-
-      while ($time < NOISE_CUTOFF_TIME_NS) begin
-        uvma_interrupt_seq_item_c irq_req;
-
-        `uvm_do_on_with(irq_req, p_sequencer.interrupt_sequencer, {
-          action        == UVMA_INTERRUPT_SEQ_ITEM_ACTION_DEASSERT;
-          (irq_mask & local::reserved_irq_mask) == 0;
-        })
+        foreach (irq_req.irq_mask[i]) begin
+          if (irq_req.irq_mask[i]) begin
+            outstanding_until_ack[i]       = 1;
+            outstanding_until_ack_since[i] = $time;
+          end
+        end
 
         rand_delay();
 
       end
     end
 
-    begin : gen_deassert
+    begin : gen_assert_and_deassert_with_cleanup
 
-      repeat (initial_delay_deassert) @(cntxt.interrupt_cntxt.vif.drv_cb);
+      fork
+        begin : gen_assert
 
-      while ($time < NOISE_CUTOFF_TIME_NS) begin
-        uvma_interrupt_seq_item_c irq_req;
+          repeat (initial_delay_assert) @(cntxt.interrupt_cntxt.vif.drv_cb);
 
-        `uvm_do_on_with(irq_req, p_sequencer.interrupt_sequencer, {
-          action        == UVMA_INTERRUPT_SEQ_ITEM_ACTION_ASSERT;
-          (irq_mask & local::reserved_irq_mask) == 0;
-        })
+          while ($time < NOISE_CUTOFF_TIME_NS) begin
+            uvma_interrupt_seq_item_c irq_req;
 
-        rand_delay();
+            `uvm_do_on_with(irq_req, p_sequencer.interrupt_sequencer, {
+              action        == UVMA_INTERRUPT_SEQ_ITEM_ACTION_DEASSERT;
+              (irq_mask & local::reserved_irq_mask) == 0;
+            })
 
+            rand_delay();
+
+          end
+        end
+
+        begin : gen_deassert
+
+          repeat (initial_delay_deassert) @(cntxt.interrupt_cntxt.vif.drv_cb);
+
+          while ($time < NOISE_CUTOFF_TIME_NS) begin
+            uvma_interrupt_seq_item_c irq_req;
+
+            `uvm_do_on_with(irq_req, p_sequencer.interrupt_sequencer, {
+              action        == UVMA_INTERRUPT_SEQ_ITEM_ACTION_ASSERT;
+              (irq_mask & local::reserved_irq_mask) == 0;
+            })
+
+            rand_delay();
+
+          end
+        end
+      join
+
+      // gen_deassert's plain ASSERT actions have no self-clear (see class-level comment
+      // above): assert_irq() releases its per-bit semaphore immediately after driving the
+      // edge, so a bit it set can only ever clear via a later DEASSERT lucky enough to hit
+      // the same bit, or a DUT irq_ack for that exact id. Once both threads above stop at
+      // the cutoff, nothing is left running that will ever issue that lucky DEASSERT, and if
+      // irq_ack never comes (e.g. the generated ISR doesn't ack that specific cause), the bit
+      // stays pending forever -- observed as a 100ms watchdog timeout on
+      // corev_rand_interrupt, with the core endlessly re-taking the same still-pending fast
+      // interrupt and never returning to the test program.
+      //
+      // Wait comfortably longer than the max per-bit skew (always [1:32] cycles -- see
+      // uvma_interrupt_seq_item_c::default_skew_c) so any still-in-flight skewed edge from
+      // either thread's last issued item has landed, then force every non-reserved line back
+      // to deasserted. deassert_irq() (uvma_interrupt_drv.sv) is a safe no-op on any bit
+      // currently owned by an in-flight assert_irq_until_ack(), so this can't disturb that
+      // mechanism's own bookkeeping.
+      repeat (64) @(cntxt.interrupt_cntxt.vif.drv_cb);
+
+      begin
+        uvma_interrupt_seq_item_c cleanup_req;
+
+        `uvm_create_on(cleanup_req, p_sequencer.interrupt_sequencer);
+        start_item(cleanup_req);
+        // uvma_interrupt_seq_item_c::irq_mask_c caps $countones(irq_mask) at 31
+        // (it's tuned for general-purpose noise generation), but this cleanup
+        // needs the full complement of reserved_irq_mask, which is all 32 bits
+        // whenever reserved_irq_mask happens to randomize to 0. With irq_mask_c
+        // left enabled that case is unsatisfiable, randomize() fails, this
+        // cleanup silently never sends, and a line left asserted by
+        // gen_deassert's non-self-clearing ASSERT (see comment above) can be
+        // left stuck pending past the cutoff with nothing left running that will
+        // ever clear it (the exact failure mode described above). Disable it
+        // here since the inline constraint below fully determines irq_mask
+        // anyway.
+        cleanup_req.irq_mask_c.constraint_mode(0);
+        assert(cleanup_req.randomize() with {
+          action   == UVMA_INTERRUPT_SEQ_ITEM_ACTION_DEASSERT;
+          irq_mask == ~local::reserved_irq_mask;
+        });
+        finish_item(cleanup_req);
       end
     end
   join

--- a/env/uvme/vseq/uvme_cv32e20_interrupt_noise_vseq.sv
+++ b/env/uvme/vseq/uvme_cv32e20_interrupt_noise_vseq.sv
@@ -285,7 +285,7 @@ task uvme_cv32e20_interrupt_noise_c::body();
         finish_item(irq_req);
 
         foreach (irq_req.irq_mask[i]) begin
-          if (irq_req.irq_mask[i]) begin
+          if (irq_req.irq_mask[i] && !outstanding_until_ack[i]) begin
             outstanding_until_ack[i]       = 1;
             outstanding_until_ack_since[i] = $time;
           end

--- a/env/uvme/vseq/uvme_cv32e20_nmi_assert_vseq.sv
+++ b/env/uvme/vseq/uvme_cv32e20_nmi_assert_vseq.sv
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+// Copyright 2026 OpenHW Group
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+`ifndef __UVME_CV32E20_NMI_ASSERT_VSEQ_SV__
+`define __UVME_CV32E20_NMI_ASSERT_VSEQ_SV__
+
+/**
+ * Virtual sequence that deterministically asserts the NMI line
+ * (irq_uvma[0] -> irq_nm_i, see uvmt_cv32e20_dut_wrap.sv) exactly once,
+ * after a bounded random delay, and waits for the DUT to ack it.
+ *
+ * Deliberately kept separate from uvme_cv32e20_interrupt_noise_c: that
+ * class's job is broad, sustained random noise across all 32 lines, with
+ * a lot of hardening (livelock avoidance, stuck-bit tracking, a WFI-paced
+ * cutoff) built up specifically for that job. A single deterministic NMI
+ * assertion doesn't need any of that -- reusing the noise vseq for this
+ * would mean depending on (and risking disturbing) machinery this doesn't
+ * need. This just sends one UVMA_INTERRUPT_SEQ_ITEM_ACTION_ASSERT_UNTIL_ACK
+ * request with irq_mask == 32'h1 straight to the interrupt sequencer,
+ * exactly the same primitive the noise vseq itself calls down to.
+ */
+class uvme_cv32e20_nmi_assert_c extends uvme_cv32e20_base_vseq_c;
+
+   // Bounded random delay (in interrupt-driver clock cycles) before the NMI
+   // is asserted, so it doesn't always land at the exact same point in a
+   // test's execution.
+   rand int unsigned initial_delay;
+
+   constraint valid_initial_delay_c {
+     initial_delay dist { [0:100]     :/ 3,
+                           [100:1000] :/ 4,
+                           [1000:5000]:/ 3};
+   }
+
+   `uvm_object_utils(uvme_cv32e20_nmi_assert_c)
+
+   /**
+    * Default constructor.
+    */
+   extern function new(string name="uvme_cv32e20_nmi_assert");
+
+   /**
+    * Waits initial_delay cycles, then asserts NMI (irq_mask bit 0) until
+    * the DUT acks it.
+    */
+   extern virtual task body();
+
+endclass : uvme_cv32e20_nmi_assert_c
+
+
+function uvme_cv32e20_nmi_assert_c::new(string name="uvme_cv32e20_nmi_assert");
+
+   super.new(name);
+
+endfunction : new
+
+
+task uvme_cv32e20_nmi_assert_c::body();
+
+   uvma_interrupt_seq_item_c irq_req;
+
+   repeat (initial_delay) @(cntxt.interrupt_cntxt.vif.drv_cb);
+
+   `uvm_info("NMIASSERT", "Asserting NMI (irq_mask[0])", UVM_NONE)
+
+   `uvm_create_on(irq_req, p_sequencer.interrupt_sequencer);
+   start_item(irq_req);
+   assert(irq_req.randomize() with {
+     action       == UVMA_INTERRUPT_SEQ_ITEM_ACTION_ASSERT_UNTIL_ACK;
+     repeat_count == 1;
+     irq_mask     == 32'h1;
+   });
+   finish_item(irq_req);
+
+   `uvm_info("NMIASSERT", "NMI asserted and acked", UVM_NONE)
+
+endtask : body
+
+`endif // __UVME_CV32E20_NMI_ASSERT_VSEQ_SV__

--- a/mk/Common.mk
+++ b/mk/Common.mk
@@ -837,7 +837,8 @@ rvvi_stub:
 	@echo "$(BANNER)"
 	@echo "Building $(RVVI_STUB)"
 	@echo "$(BANNER)"
-	$(RVVI_STUB_CXX) $(RVVI_STUB_CFLAGS) $(RVVI_STUB_SRC) -I$(DPI_INCLUDE) -o $(RVVI_STUB_LIB)
+	$(RVVI_STUB_CXX) $(RVVI_STUB_CFLAGS) $(RVVI_STUB_SRC) -I$(DPI_INCLUDE) -o $(RVVI_STUB_LIB).$$$$.tmp && \
+	mv -f $(RVVI_STUB_LIB).$$$$.tmp $(RVVI_STUB_LIB)
 
 #endend
 

--- a/mk/Common.mk
+++ b/mk/Common.mk
@@ -534,7 +534,7 @@ ifeq ($(TEST_FIXED_ELF),1)
 	cp $(TEST_TEST_DIR)/$(TEST).elf $@
 else
 ifeq ($(TEST_ACT),1)
-%.elf: $(TEST_FILES)
+%.elf: $(TEST_FILES) $(wildcard $(BSP)/*.S $(BSP)/*.c $(BSP)/*.h $(BSP)/link.ld)
 	mkdir -p $(SIM_TEST_PROGRAM_RESULTS)
 	make bsp ACT=1
 	@echo "$(BANNER)"
@@ -556,7 +556,7 @@ ifeq ($(TEST_ACT),1)
 #		-lcv-verif
 
 else
-%.elf: $(TEST_FILES)
+%.elf: $(TEST_FILES) $(wildcard $(BSP)/*.S $(BSP)/*.c $(BSP)/*.h $(BSP)/link.ld)
 	mkdir -p $(SIM_TEST_PROGRAM_RESULTS)
 	make bsp
 	@echo "$(BANNER)"

--- a/mk/uvmt/README.md
+++ b/mk/uvmt/README.md
@@ -3,3 +3,17 @@ Tool-specific Makefiles for the CORE-V-VERIF UVM Verification Environment
 This directory contains a set of simulator-specific Makefiles.
 The Makefile selected is controlled by the `CV_SIMULATOR` shell environment variable.
 For more information see Makefiles in [../README](../README.md#makefiles).
+
+## Coverage "holes" reports (`vsim.mk`)
+
+`cov_holes` and `cov_holes_details` report only what's *not* fully covered,
+omitting any instance/coverage-type that's already at or above
+`COV_HOLES_THRESHOLD` (default 100):
+
+- `cov_holes` — compact: just the remaining coverage percentages, no source.
+- `cov_holes_details` — same filtering, plus full source-line detail for
+  whatever's still incomplete.
+
+Both accept the same `TEST=`/`MERGE=YES`/`COV_INSTANCE=` options as `cov`,
+and write to `<COV_DIR>/cov_report/cov_holes[_details]`. See
+`docs/COVERAGE-MAKE-TARGETS.md` for the full set of coverage targets.

--- a/mk/uvmt/vsim.mk
+++ b/mk/uvmt/vsim.mk
@@ -57,7 +57,7 @@ DPI_INCLUDE            ?= $(QUESTASIM_HOME)/include
 
 # Default flags
 VSIM_USER_FLAGS        ?=
-VOPT_COV               ?= +cover=$(COV_TYPES)$(if $(COV_INSTANCE),+$(COV_INSTANCE))
+VOPT_COV               ?= +cover=$(COV_TYPES)$(if $(COV_INSTANCE),+$(COV_INSTANCE).)
 VSIM_COV               ?= -coverage
 VOPT_WAVES_ADV_DEBUG   ?= -designfile design.bin
 VSIM_WAVES_ADV_DEBUG   ?= -qwavedb=+signal+assertion+ignoretxntime+msgmode=both
@@ -505,10 +505,21 @@ gen_ovpsim_ic:
 export IMPERAS_TOOLS=$(SIM_RUN_RESULTS)/ovpsim.ic
 
 # Target to create work directory in $(VSIM_RESULTS)/
+#
+# Always wipe and recreate rather than conditionally preserving an existing
+# library: re-running `vopt -o $(RTLSRC_VOPT_TB_TOP)` against a work library
+# that already holds an optimized snapshot from a prior `make comp` (e.g. a
+# second/third regression run reusing the same results directory) has been
+# observed to silently produce an incomplete design -- vopt exits 0 but skips
+# real elaboration (no FSM recognition messages, no +cover instrumentation
+# actually applied) with no error anywhere in the chain. `vlog` below already
+# unconditionally recompiles every source file on every `make comp` regardless
+# of whether the library is fresh, so this costs no real incremental-compile
+# time -- it just removes the possibility of a stale optimized snapshot
+# colliding with a fresh one.
 lib: mk_vsim_dir  $(CV_CORE_PKG) $(CV_VERIF_PKG) rvvi_stub $(SVLIB_PKG) $(TBSRC_PKG) $(TBSRC)
-	if [ ! -d "$(SIM_CFG_RESULTS)/$(VWORK)" ]; then \
-		$(VLIB) $(SIM_CFG_RESULTS)/$(VWORK); \
-	fi
+	rm -rf $(SIM_CFG_RESULTS)/$(VWORK)
+	$(VLIB) $(SIM_CFG_RESULTS)/$(VWORK)
 
 # Target to run vlog over SystemVerilog source in $(VSIM_RESULTS)/
 vlog: $(LIBS) lib

--- a/mk/uvmt/vsim.mk
+++ b/mk/uvmt/vsim.mk
@@ -33,9 +33,23 @@ VCOVER                  = vcover
 # Paths
 QUESTASIM_HOME         ?= $(abspath $(shell which $(VLIB))/../../)
 VWORK                   = work
-VSIM_COV_MERGE_DIR      = $(SIM_CFG_RESULTS)/$(CFG)/merged
+VSIM_COV_MERGE_DIR      = $(SIM_CFG_RESULTS)/merged
 UVM_HOME                = $(QUESTASIM_HOME)/verilog_src/uvm-1.2/src
 USES_DPI = 1
+
+# Criteria for OpenHW TRL5: 
+# https://docs.google.com/presentation/d/1B_kt_JEcLfm1e7IEwnnPGHXxc1ww2tLA/edit?slide=id.g28866f3cbf4_0_54#slide=id.g28866f3cbf4_0_54
+# 100% Line, Condition, FSM state and Branch coverage. Signed-off waivers for any uncovered lines or conditions.
+#
+# b=branch coverage; c=condition coverage; e=expression coverage; s=statement coverage==line; t=toggle; f=Finite State Machine coverage
+COV_TYPES              ?= bcsf
+
+# Default coverage report scope: the DUT and below only, excluding the
+# testbench itself (agents, interfaces, etc.). Used by COV_INST_ARG (below)
+# to build -instance=<path>. for the cov*/trl5_coverage_metrics targets.
+# Override e.g. `make cov_holes COV_INSTANCE=` for whole-design coverage, or
+# to any other subtree.
+COV_INSTANCE           ?= /uvmt_cv32e20_tb/dut_wrap/cv32e20_top_i
 
 # Special var to point to tool and installation dependent path of DPI headers.
 # Used to recompile dpi_dasm_spike if needed (by default, not needed).
@@ -43,7 +57,8 @@ DPI_INCLUDE            ?= $(QUESTASIM_HOME)/include
 
 # Default flags
 VSIM_USER_FLAGS        ?=
-VOPT_COV               ?= +cover=setf+$(RTLSRC_VLOG_TB_TOP).
+VOPT_COV               ?= +cover=$(COV_TYPES)+$(COV_INSTANCE).
+#VOPT_COV               ?= +cover=$(COV_TYPES)
 VSIM_COV               ?= -coverage
 VOPT_WAVES_ADV_DEBUG   ?= -designfile design.bin
 VSIM_WAVES_ADV_DEBUG   ?= -qwavedb=+signal+assertion+ignoretxntime+msgmode=both
@@ -58,7 +73,11 @@ endif
 
 ifeq ($(USES_DPI),1)
 	DPILIB_VLOG_OPT =
-	DPILIB_VSIM_OPT = -sv_lib $(QUESTASIM_HOME)/uvm-1.2/linux_x86_64/uvm_dpi
+# 	OS_ARCH := $(shell vsim -c -do "puts \"\$tcl_platform(os)_\$tcl_platform(machine)\"; quit -f")
+	OS = $(shell uname -s | tr A-Z a-z)
+ 	ARCH = $(shell uname -m)
+	DPILIB_VSIM_OPT = -sv_lib $(QUESTASIM_HOME)/uvm-1.2/$(OS)_$(ARCH)/uvm_dpi
+	DPILIB_TARGET = dpi_lib$(BITS)
 	DPILIB_TARGET = dpi_lib$(BITS)
 else
 	DPILIB_VLOG_OPT = +define+UVM_NO_DPI
@@ -86,7 +105,6 @@ VLOG_LDGEN_FLAGS ?= \
                     -suppress 13288 \
                     -suppress 2181 \
                     -suppress 13262 \
-                    -suppress 2697 \
                     -timescale "1ns/1ps" \
                     -sv \
                     -mfcu \
@@ -97,7 +115,6 @@ VOPT_LDGEN_FLAGS ?= \
                     -debugdb \
                     -fsmdebug \
                     -suppress 7034 \
-                    -suppress 2697 \
                     +acc \
                     $(QUIET)
 
@@ -118,7 +135,6 @@ VLOG_FLAGS	?= \
 		-suppress 13071 \
 		-suppress 13401 \
 		-suppress vlog-2745 \
-		-suppress 2697 \
 		-timescale "1ns/1ps" \
 		-sv \
 		-64 \
@@ -139,12 +155,12 @@ ifeq ($(call IS_YES,$(USE_ISS)),YES)
 		VSIM_FLAGS += -sv_lib $(SPIKE_CUSTOMEXT_LIB)
 		VSIM_FLAGS += -sv_lib $(SPIKE_RISCV_LIB)
 		VSIM_FLAGS += -sv_lib $(SPIKE_DISASM_LIB)
-		LIBS = spike_lib
+		VSIM_FLAGS += -sv_lib $(SPIKE_FESVR_LIB)
+		VSIM_FLAGS += +SPIKE
 	endif
 endif
 
 ifeq ($(call IS_YES,$(COMPILE_SPIKE)),YES)
-	VSIM_FLAGS += -sv_lib $(SPIKE_FESVR_LIB)
 	LIBS = spike_lib
 endif
 
@@ -159,7 +175,6 @@ VOPT_FLAGS    ?= \
                  -debugdb \
                  -fsmdebug \
                  -suppress 7034 \
-                 -suppress 2697 \
                  +acc \
                  $(QUIET)
 
@@ -184,7 +199,11 @@ VSIM_SCRIPT_DIR   = $(abspath $(MAKE_PATH)/../tools/vsim)
 VSIM_UVM_ARGS     = +incdir+$(UVM_HOME)/src $(UVM_HOME)/src/uvm_pkg.sv
 
 ifeq ($(call IS_YES,$(USE_ISS)),YES)
-    VSIM_FLAGS += -sv_lib $(basename $(OVP_MODEL_DPI))
+	ifeq ($(ISS),IMPERAS)
+		VSIM_FLAGS += -sv_lib $(basename $(OVP_MODEL_DPI))
+	else
+		VSIM_FLAGS += +DISABLE_OVPSIM
+	endif
 	VSIM_FLAGS += +USE_ISS
 else
 	VSIM_FLAGS += +DISABLE_OVPSIM
@@ -246,32 +265,40 @@ VSIM_FLAGS += -do $(VSIM_SCRIPT_DIR)/vsim.tcl
 # Coverage command
 COV_FLAGS =
 COV_REPORT = cov_report
+COV_INST_ARG = $(if $(COV_INSTANCE),-instance=$(COV_INSTANCE).,)
+# Threshold for the cov_holes/cov_holes_details targets: instances/types at or
+# above this percentage are omitted from the report entirely. Override e.g.
+# `make cov_holes COV_HOLES_THRESHOLD=95` to also see near-complete items.
+COV_HOLES_THRESHOLD ?= 100
 COV_MERGE_TARGET =
-COV_MERGE_FIND = find $(SIM_CFG_RESULTS) -type f -name "*.ucdb" | grep -v merged.ucdb
+COV_MERGE_FIND = find $(abspath $(SIM_CFG_RESULTS)) -type f -name "*.ucdb" | grep -v merged.ucdb
 COV_MERGE_FLAGS=merge -64 -out merged.ucdb -inputs ucdb.list
+# Evaluated at parse time so it can serve as a file prerequisite list below --
+# lets 'make' skip re-merging (and skip re-running any target that depends on
+# it, e.g. cov_holes) when merged.ucdb is already newer than every per-test
+# .ucdb it would be built from.
+COV_MERGE_UCDB_LIST := $(shell $(COV_MERGE_FIND))
 
 ifeq ($(call IS_YES,$(MERGE)),YES)
 	COV_DIR=$(VSIM_COV_MERGE_DIR)
-	COV_MERGE_TARGET=cov_merge
+	COV_UCDB=merged.ucdb
+	COV_MERGE_TARGET=$(VSIM_COV_MERGE_DIR)/merged.ucdb
+	ifeq ($(call IS_YES,$(GUI)),YES)
+		# Merged coverage GUI
+		COV_FLAGS=-viewcov $(VSIM_COV_MERGE_DIR)/merged.ucdb
+	else
+		# Merged coverage report
+		COV_FLAGS=-c -viewcov $(VSIM_COV_MERGE_DIR)/merged.ucdb -do "file delete -force $(COV_REPORT); coverage report -html -details -precision 2 -annotate $(COV_INST_ARG) -code $(COV_TYPES) -output $(COV_REPORT); exit -f"
+	endif
 else
 	COV_DIR=$(SIM_RUN_RESULTS)
-
-	ifeq ($(call IS_YES,$(MERGE)),YES)
-		ifeq ($(call IS_YES,$(GUI)),YES)
-            # Merged coverage GUI
-			COV_FLAGS=-viewcov $(VSIM_COV_MERGE_DIR)/merged.ucdb
-		else
-            # Merged coverage report
-			COV_FLAGS=-c -viewcov $(VSIM_COV_MERGE_DIR)/merged.ucdb -do "file delete -force $(COV_REPORT); coverage report -html -details -precision 2 -annotate -output $(COV_REPORT); exit -f"
-		endif
+	COV_UCDB=$(TEST).ucdb
+	ifeq ($(call IS_YES,$(GUI)),YES)
+		# Test coverage GUI
+		COV_FLAGS=-viewcov $(TEST).ucdb
 	else
-		ifeq ($(call IS_YES,$(GUI)),YES)
-            # Test coverage GUI
-			COV_FLAGS=-viewcov $(TEST).ucdb
-		else
-            # Test coverage report
-			COV_FLAGS=-c -viewcov $(TEST).ucdb -do "file delete -force $(COV_REPORT); coverage report -html -details -precision 2 -annotate -output $(COV_REPORT); exit -f"
-		endif
+		# Test coverage report
+		COV_FLAGS=-c -viewcov $(TEST).ucdb -do "file delete -force $(COV_REPORT); coverage report -html -details -precision 2 -annotate $(COV_INST_ARG) -code $(COV_TYPES) -output $(COV_REPORT); exit -f"
 	endif
 endif
 
@@ -300,7 +327,7 @@ endif
 ################################################################################
 # Targets
 
-.PHONY: no_rule help mk_vsim_dir lib comp opt run
+.PHONY: no_rule help mk_vsim_dir lib comp opt run cov_merge
 
 no_rule:
 	@echo 'makefile: SIMULATOR is set to $(SIMULATOR), but no rule/target specified.'
@@ -567,17 +594,65 @@ waves:
 
 ################################################################################
 # Invoke coverage
-cov_merge:
+#
+# merged.ucdb is a real file target, keyed on the per-test .ucdb files found
+# at parse time (COV_MERGE_UCDB_LIST): 'make cov_merge' (or any cov* target
+# with MERGE=YES, which depends on this same file via COV_MERGE_TARGET) only
+# re-merges when merged.ucdb is missing or older than one of its inputs.
+# Re-running a test regenerates that test's .ucdb with a fresh mtime, so the
+# next merge picks it up automatically -- no manual cache-busting needed.
+$(VSIM_COV_MERGE_DIR)/merged.ucdb: $(COV_MERGE_UCDB_LIST)
 	$(MKDIR_P) $(VSIM_COV_MERGE_DIR)
-	cd $(VSIM_COV_MERGE_DIR) && \
-		$(COV_MERGE_FIND) > $(VSIM_COV_MERGE_DIR)/ucdb.list
+	$(COV_MERGE_FIND) > $(VSIM_COV_MERGE_DIR)/ucdb.list
 	cd $(VSIM_COV_MERGE_DIR) && \
 		$(VCOVER) \
 			$(COV_MERGE_FLAGS)
+cov_merge: $(VSIM_COV_MERGE_DIR)/merged.ucdb
 cov: $(COV_MERGE_TARGET)
 	cd $(COV_DIR) && \
 		$(VSIM) \
 			$(COV_FLAGS)
+
+# Flat ASCII text coverage report, generated directly from the UCDB via vcover
+# (no vsim invocation needed). Respects MERGE/TEST/COV_INSTANCE the same way
+# the HTML 'cov' target does. Output: <COV_DIR>/$(COV_REPORT)/cov_txt
+cov_txt: $(COV_MERGE_TARGET)
+	$(MKDIR_P) $(COV_DIR)/$(COV_REPORT)
+	cd $(COV_DIR) && \
+		$(VCOVER) report \
+			-details -precision 2 -annotate $(COV_INST_ARG) -code $(COV_TYPES) \
+			-output $(COV_REPORT)/cov_txt \
+			$(COV_UCDB)
+
+# Compact "holes" report: instances/coverage-types at or above
+# COV_HOLES_THRESHOLD are omitted entirely, no source-line detail -- just
+# what's still short of the threshold. Output: <COV_DIR>/$(COV_REPORT)/cov_holes
+cov_holes: $(COV_MERGE_TARGET)
+	$(MKDIR_P) $(COV_DIR)/$(COV_REPORT)
+	cd $(COV_DIR) && \
+		$(VCOVER) report \
+			-precision 2 -below $(COV_HOLES_THRESHOLD) $(COV_INST_ARG) -code $(COV_TYPES) \
+			-output $(COV_REPORT)/cov_holes \
+			$(COV_UCDB)
+
+# Detailed "holes" report: same instance/type filtering as cov_holes, but with
+# full source-line detail (hits and misses) for whatever remains below
+# COV_HOLES_THRESHOLD. Output: <COV_DIR>/$(COV_REPORT)/cov_holes_details
+cov_holes_details: $(COV_MERGE_TARGET)
+	$(MKDIR_P) $(COV_DIR)/$(COV_REPORT)
+	cd $(COV_DIR) && \
+		$(VCOVER) report \
+			-details -precision 2 -annotate -below $(COV_HOLES_THRESHOLD) $(COV_INST_ARG) -code $(COV_TYPES) \
+			-output $(COV_REPORT)/cov_holes_details \
+			$(COV_UCDB)
+
+# Target to extract TRL5 coverage metrics
+trl5_coverage_metrics:
+	$(MKDIR_P) $(VSIM_COV_MERGE_DIR)
+	cd $(VSIM_COV_MERGE_DIR) && \
+		COV_INSTANCE="$(COV_INSTANCE)" $(VCOVER) \
+		load merged.ucdb -test dummy -run $(VSIM_SCRIPT_DIR)/coverage_extract.tcl \
+		> $(VSIM_COV_MERGE_DIR)/trl5_metrics.txt
 
 ###############################################################################
 # Clean up your mess!

--- a/mk/uvmt/vsim.mk
+++ b/mk/uvmt/vsim.mk
@@ -57,8 +57,7 @@ DPI_INCLUDE            ?= $(QUESTASIM_HOME)/include
 
 # Default flags
 VSIM_USER_FLAGS        ?=
-VOPT_COV               ?= +cover=$(COV_TYPES)+$(COV_INSTANCE).
-#VOPT_COV               ?= +cover=$(COV_TYPES)
+VOPT_COV               ?= +cover=$(COV_TYPES)$(if $(COV_INSTANCE),+$(COV_INSTANCE))
 VSIM_COV               ?= -coverage
 VOPT_WAVES_ADV_DEBUG   ?= -designfile design.bin
 VSIM_WAVES_ADV_DEBUG   ?= -qwavedb=+signal+assertion+ignoretxntime+msgmode=both
@@ -77,7 +76,6 @@ ifeq ($(USES_DPI),1)
 	OS = $(shell uname -s | tr A-Z a-z)
  	ARCH = $(shell uname -m)
 	DPILIB_VSIM_OPT = -sv_lib $(QUESTASIM_HOME)/uvm-1.2/$(OS)_$(ARCH)/uvm_dpi
-	DPILIB_TARGET = dpi_lib$(BITS)
 	DPILIB_TARGET = dpi_lib$(BITS)
 else
 	DPILIB_VLOG_OPT = +define+UVM_NO_DPI
@@ -647,7 +645,7 @@ cov_holes_details: $(COV_MERGE_TARGET)
 			$(COV_UCDB)
 
 # Target to extract TRL5 coverage metrics
-trl5_coverage_metrics:
+trl5_coverage_metrics: $(VSIM_COV_MERGE_DIR)/merged.ucdb
 	$(MKDIR_P) $(VSIM_COV_MERGE_DIR)
 	cd $(VSIM_COV_MERGE_DIR) && \
 		COV_INSTANCE="$(COV_INSTANCE)" $(VCOVER) \

--- a/sim/ExternalRepos.mk
+++ b/sim/ExternalRepos.mk
@@ -15,10 +15,12 @@ export SHELL = /bin/bash
 #CV_CORE_HASH   ?= a24bbd2
 
 CV_CORE_REPO   ?= https://github.com/MikeOpenHWGroup/cve2
-CV_CORE_BRANCH ?= umode
+CV_CORE_BRANCH ?= rm_defunct_asserts
+#CV_CORE_BRANCH ?= umode
+CV_CORE_HASH   ?= d9c8b8f
 #CV_CORE_HASH   ?= f217917
 #CV_CORE_HASH   ?= ed46a40ffd552fc7a0a590b242dcf46c4ee9cf42
-CV_CORE_HASH   ?= facf23c030a57ab1c762968c50a5ef9ec454fd88
+#CV_CORE_HASH   ?= facf23c030a57ab1c762968c50a5ef9ec454fd88
 
 #CV_VERIF_REPO   ?= https://github.com/openhwgroup/core-v-verif
 #CV_VERIF_BRANCH ?= cv32e20-dv/dev

--- a/sim/tools/vsim/cov.tcl
+++ b/sim/tools/vsim/cov.tcl
@@ -1,0 +1,573 @@
+
+# Control variable for CV-X-IF exclusions, enabled only for the CV32E20X config
+set XInterface 0
+set CV_XIF_DISABLED_COMMENT {Only used when CV-X-IF is enabled (CV32E20X)}
+
+# Bitmanip operations extension. Disabled for the CVE2.
+set RVB 0
+set RVB_DISABLED_COMMENT {RVB (Bitmanip) is disabled on the CVE2}
+
+# U-mode support. cve2_cs_registers.sv:113 hardcodes
+# `localparam int unsigned UmodeEnabled = 0` -- a bare localparam, not a
+# module parameter, not wired to anything in cve2_core.sv/cve2_top.sv (this
+# is nonetheless the CVE2 "umode" branch). If UmodeEnabled is ever wired up,
+# every exclusion gated on this variable needs revisiting.
+set UmodeEnabled 0
+set UMODE_DISABLED_COMMENT {UmodeEnabled=0 is hardcoded in cve2_cs_registers.sv -- umode_control is permanently 0, so any check that could distinguish PRIV_LVL_U from PRIV_LVL_M is structurally unreachable. See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.}
+
+
+# cve2_load_store_unit
+# ====================
+#
+#   Narrowed 2026-08-10 from a bare, undocumented, pre-existing bundle
+#   (`-linerange 124 140 154 372-381 428-443`) that predates this session.
+#   That bundle wrongly excluded genuinely reachable, exercised RTL: the
+#   WAIT_GNT_MIS->WAIT_RVALID_MIS transition and the WAIT_RVALID_MIS case
+#   item's own entry point (372-381) -- proven live via 530 hits on that
+#   state's nested statements, which sit just outside the old range --
+#   plus misaligned-write byte-enable generation (124, 140, 154) and part
+#   of the FSM register's reset block (within 428-443). Only the `default:`
+#   case of ls_fsm_e is genuinely dead (logic [2:0], 3 bits/8 encodings,
+#   only 5 named/assigned anywhere in the FSM -- same exhaustive-default
+#   pattern as the earlier default-case audit). See
+#   docs/RTL-STATEMENT-COVERAGE-AUDIT.md.
+coverage exclude -du cve2_load_store_unit -linerange 433-434 -comment {ls_fsm_e default case: register is logic [2:0] (8 encodings) but only 5 are named/assigned anywhere in the FSM -- the other 3 encodings are structurally unreachable, same pattern as the earlier default-case audit.}
+
+#   3 more genuinely dead lines found while narrowing the bundle above
+#   (verified 2026-08-10, see docs/RTL-STATEMENT-COVERAGE-AUDIT.md):
+#   - line 124 (2'b00: data_be = 4'b0000;, word-write "second part" case):
+#     the address increment for a misaligned access's second half is always
+#     exactly +4 (cve2_id_stage.sv:450, IMM_B_INCR_ADDR: imm_b = 32'h4;),
+#     which never changes address bits [1:0] -- and word-access splitting
+#     only triggers when the first part's data_offset != 2'b00 (line 327),
+#     so the second part's data_offset (same bits, unchanged by +4) can
+#     never be 2'b00. Matches the RTL's own comment ("this is not used").
+#   - lines 140, 154 (default: data_be = 4'b1111;, half-word/byte cases):
+#     both are `default:` inside `unique case (data_offset)`, a plain 2-bit
+#     signal, with all 4 possible encodings (00/01/10/11) already
+#     explicitly enumerated -- exhaustive case, same pattern as the earlier
+#     default-case audit.
+#     NOTE (2026-08-12): these three -linerange targets were previously
+#     122/138/152 -- stale by exactly 2 lines (same drift-by-2 pattern found
+#     several more times this session, e.g. cve2_cs_registers' UmodeEnabled
+#     block and the earlier cve2_cs_registers PMP-CSR-read exclusion).
+#     Found via a design-wide branch-coverage holes sweep: clearing the
+#     stale exclusions and inspecting the live report showed lines 138/152
+#     (real, legitimate `2'b10:` case items, NOT defaults) had been
+#     silently hidden from the coverage metric with real hits (14448 and
+#     25749 respectively) never counted, while the genuinely dead defaults
+#     at 140/154 remained open, uncounted misses the whole time. Fixed by
+#     re-pointing at the current correct line numbers, verified via a
+#     -viewcov dry run before applying to this file.
+coverage exclude -du cve2_load_store_unit -linerange 124 -comment {Word-write second-part byte-enable: unreachable because the +4 address increment (cve2_id_stage.sv IMM_B_INCR_ADDR) never changes address bits [1:0], and splitting only triggers when the first part's data_offset is nonzero -- so the second part's data_offset can never be 2'b00. Matches the RTL's own comment.}
+coverage exclude -du cve2_load_store_unit -linerange 140 -comment {default case of unique case (data_offset), a plain 2-bit signal with all 4 encodings (00/01/10/11) already explicitly enumerated -- exhaustive, same pattern as the earlier default-case audit.}
+coverage exclude -du cve2_load_store_unit -linerange 154 -comment {default case of unique case (data_offset), a plain 2-bit signal with all 4 encodings (00/01/10/11) already explicitly enumerated -- exhaustive, same pattern as the earlier default-case audit.}
+
+#   Lines 148 and 318 -- `lsu_type_i`/`data_type_q`'s `2'b11` value (both
+#   drive `unique case`s where 2'b10/2'b11 are grouped as "byte"). Traced
+#   the whole decoder assignment set for `data_type_o` (which feeds
+#   `lsu_type_i` directly): it's initialized to `2'b00` at the top of
+#   cve2_decoder.sv's single decode `always_comb` (line 227) and only ever
+#   overridden inside the OPCODE_STORE (310-312: sb->2'b10, sh->2'b01,
+#   sw->2'b00) and OPCODE_LOAD (327-330: lb(u)->2'b10, lh(u)->2'b01,
+#   lw->2'b00) case blocks -- `2'b11` is never assigned anywhere. Line 148
+#   (`2'b11: begin // Writing a byte`, grouped with the genuinely-hit
+#   `2'b10` at line 147) and line 318 (`2'b10,2'b11: data_rdata_ext =
+#   rdata_b_ext;`, `data_type_q` being the registered form of the same
+#   never-2'b11 signal) are both structurally unreachable. Found 2026-08-12
+#   auditing branch-coverage holes; verified via -viewcov dry run alongside
+#   the fix above. See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.
+coverage exclude -du cve2_load_store_unit -linerange 148 -code b -comment {lsu_type_i can never be 2'b11: data_type_o (decoder) is initialized to 2'b00 and only ever overridden to 2'b00/01/10 in the STORE/LOAD case blocks. See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.}
+coverage exclude -du cve2_load_store_unit -linerange 318 -code b -comment {data_type_q (registered lsu_type_i) can never be 2'b11, same root cause as line 148. See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.}
+
+#   ls_fsm_cs FSM transition: WAIT_GNT_MIS -> IDLE. Same pattern/rationale
+#   as ctrl_fsm_cs and md_state_q above: NOT dead code -- WAIT_GNT_MIS's
+#   only functional next-state target is WAIT_RVALID_MIS (line 372); the
+#   only way to reach IDLE from WAIT_GNT_MIS is the async reset
+#   (`ls_fsm_cs <= IDLE;`, line 442, inside `if (!rst_ni)`), which is a
+#   real, reachable scenario, just untested by the current suite (same
+#   mid-run-reset gap as the other two FSMs). Excluded per the same
+#   explicit user decision (2026-08-10). See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.
+coverage exclude -du cve2_load_store_unit -ftrans ls_fsm_cs {WAIT_GNT_MIS->IDLE} -comment {rst_ni can legitimately drop while in WAIT_GNT_MIS -- not dead code, an accepted untested-stimulus gap (mid-run reset injection). See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.}
+
+#   Lines 377, 392, 419: `(data_gnt_i||pmp_err_q)`/`(data_rvalid_i||pmp_err_q)`.
+#   pmp_err_q is a register fed by the module input data_pmp_err_i (lines
+#   355/394/435: pmp_err_d = data_pmp_err_i), which traces up through
+#   cve2_core.sv:591 to pmp_req_err[PMP_D]. With PMPEnable hardcoded false
+#   (cve2_top.sv:128), elaboration always takes the g_no_pmp branch
+#   (cve2_core.sv:854-869), which ties pmp_req_err[PMP_D] = 1'b0 as a
+#   constant net, not a runtime-gated 0. So pmp_err_d can only ever be
+#   assigned 1'b0 or hold its already-0 previous value, and pmp_err_q
+#   (reset to '0) can never become 1 -- the pmp_err_q_1 FEC row in each of
+#   these three conditions is structurally unreachable, same PMPEnable=0
+#   dead-code family as the existing cve2_cs_registers PMP-CSR-read
+#   exclusion above. Confirmed empirically: 0 hits across all 32
+#   regression tests while the sibling data_gnt_i/data_rvalid_i rows hit
+#   normally. See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.
+coverage exclude -du cve2_load_store_unit -feccondrow 377 4 -comment {pmp_err_q can never be 1: PMPEnable is hardcoded false (cve2_top.sv:128), so pmp_req_err[PMP_D] is tied to a constant 1'b0 at elaboration (cve2_core.sv g_no_pmp branch), and data_pmp_err_i (driving pmp_err_d) inherits that constant. See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.}
+coverage exclude -du cve2_load_store_unit -feccondrow 392 4 -comment {pmp_err_q can never be 1: PMPEnable is hardcoded false (cve2_top.sv:128), so pmp_req_err[PMP_D] is tied to a constant 1'b0 at elaboration (cve2_core.sv g_no_pmp branch), and data_pmp_err_i (driving pmp_err_d) inherits that constant. See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.}
+coverage exclude -du cve2_load_store_unit -feccondrow 419 4 -comment {pmp_err_q can never be 1: PMPEnable is hardcoded false (cve2_top.sv:128), so pmp_req_err[PMP_D] is tied to a constant 1'b0 at elaboration (cve2_core.sv g_no_pmp branch), and data_pmp_err_i (driving pmp_err_d) inherits that constant. See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.}
+
+
+# cve2_compressed_decoder
+# =======================
+#
+#   Unreachable default cases (see docs/RTL-DEAD-DEFAULT-CASES.md). The label
+#   line itself (CASE Branch bin) and the dead statement inside it (Statement
+#   bin) are separate coverage bins -- both need excluding.
+coverage exclude -du cve2_compressed_decoder -linerange 75-76 177-178 183-184 197-198 265-266
+# To review:
+# coverage exclude -du cve2_compressed_decoder -linerange 121 221 233 246
+
+# cve2_if_stage
+# =============
+#
+# Exclude dummy DPI functions needed by the former RISC-V compliance checking simulation model
+# See rtl/cve2_if_stage.sv for more info
+coverage exclude -du cve2_if_stage -linerange 181-194 -comment {Dummy sim-only simutil_get_scramble_key and simutil_get_scramble_nonce functions}
+# To review:
+# coverage exclude -du cve2_if_stage -linerange 156
+
+
+# cve2_id_stage
+# =============
+coverage exclude -du cve2_id_stage -linerange 883-884 -comment {Default case for the id_fsm_q signal}
+#   To review:
+#   coverage exclude -du cve2_if_stage -linerange 608
+
+# cve2_controller
+# ===============
+#
+#   instr_err_i and data_err_i are hardwired to 1'b0 in the design being
+#   verified (confirmed by the user, 2026-08-10) -- so instr_fetch_err_i,
+#   load_err_i, and store_err_i (which trace back through cve2_if_stage.sv/
+#   cve2_load_store_unit.sv to those two ports) are permanently 0, making
+#   the whole instr_fetch_err_prio/store_err_prio/load_err_prio access-fault
+#   exception path structurally dead:
+#   - lines 237/245/247: the true branch of each `if`/`else if` (only the
+#     false/fall-through side, checking the next priority, is reachable)
+#   - lines 238/246/248: the *_prio = 1'b1; statements those true branches
+#     guard
+#   - lines 605/650/654: the corresponding CASE branch items in the
+#     exception-cause selection (unique case (1'b1) ...), and lines
+#     606-607/651-652/655-656: the exc_cause_o/csr_mtval_o statements
+#     inside them
+#   - line 592 (`exc_req_q || store_err_q || load_err_q`): NOT excluded
+#     wholesale -- exc_req_q remains genuinely reachable (illegal
+#     instruction/ecall/ebreak/instr_fetch_err all still flow through it).
+#     Only the store_err_q/load_err_q input *terms* are dead -- condition-
+#     only exclusion (-code c), same precision as the UmodeEnabled block.
+#   See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.
+set BusErrSupported 0
+set BUS_ERR_DISABLED_COMMENT {instr_err_i/data_err_i are hardwired to 1'b0 in the design being verified -- the access-fault exception path they feed is structurally unreachable. See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.}
+if {!$BusErrSupported} {
+    coverage exclude -du cve2_controller -linerange 237 238 245 246 247 248 -comment $BUS_ERR_DISABLED_COMMENT
+    coverage exclude -du cve2_controller -linerange 605 606-607 -comment $BUS_ERR_DISABLED_COMMENT
+    coverage exclude -du cve2_controller -linerange 650 651-652 -comment $BUS_ERR_DISABLED_COMMENT
+    coverage exclude -du cve2_controller -linerange 654 655-656 -comment $BUS_ERR_DISABLED_COMMENT
+    coverage exclude -du cve2_controller -linerange 592 -code c -comment $BUS_ERR_DISABLED_COMMENT
+}
+
+#   cve2_controller.sv:658 -- `default: ;` in the exception-cause priority
+#   `unique case (1'b1) instr_fetch_err_prio: ... illegal_insn_prio: ...
+#   ecall_insn_prio: ... ebrk_insn_prio: ... store_err_prio: ...
+#   load_err_prio: ... default: ; endcase` (line 604). Unreachable, not
+#   config-dependent: the RTL's own comment at line 603 states "Exception/
+#   fault prioritisation logic will have set exactly 1 X_prio signal", and
+#   this one-hot guarantee is independently enforced by the
+#   CVE2ExceptionPrioOnehot assertion elsewhere in this file -- entering
+#   this case at all (gated by `exc_req_q || store_err_q || load_err_q` at
+#   line 592) already guarantees exactly one of the six named arms matches.
+#   Found 2026-08-12 auditing branch-coverage holes.
+#   See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.
+coverage exclude -du cve2_controller -linerange 658 -code b -comment {default arm of a one-hot exception-priority case (unique case (1'b1)), unreachable: RTL comment + the CVE2ExceptionPrioOnehot assertion both guarantee exactly one of the six named priority signals is set whenever this case is entered. See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.}
+
+#   cve2_controller.sv:501 `(irq_nm_i && ~nmi_mode_q)` -- one FEC row of this
+#   2-term condition, "nmi_mode_q sensitized to 1" (nmi_mode_q_1, the row
+#   requiring irq_nm_i to be checked again while nmi_mode_q is already 1,
+#   i.e. NMI re-asserted/held while already servicing a prior NMI), is
+#   structurally unreachable, not an untested-stimulus gap: this line is
+#   only ever evaluated during the single-cycle IRQ_TAKEN FSM state
+#   (line 490), which is only entered via handle_irq (line 476-478), and
+#   handle_irq is unconditionally 0 whenever nmi_mode_q==1 (line 301-302:
+#   `assign handle_irq = ~debug_mode_q & ~nmi_mode_q & ...`, with the RTL's
+#   own comment: "while in NMI mode (nested NMIs are not supported, NMI has
+#   highest priority and cannot be interrupted by regular interrupts)").
+#   So the FSM can never even reach the state that checks this condition
+#   while nmi_mode_q is already 1. Confirmed two ways: the RTL trace above,
+#   and empirically -- a dedicated stimulus attempt that held irq_nm_i
+#   asserted for several cycles squarely inside an active NMI handler
+#   (verified via log timestamps) still left this row at 0 hits. The other
+#   rows of this same condition, and the nmi_mode_q branch on mret (line
+#   666), are genuinely reachable and already covered by nmi_test -- only
+#   this one row is excluded. See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.
+coverage exclude -du cve2_controller -feccondrow 501 4 -comment {Nested NMI (irq_nm_i sensitized while nmi_mode_q==1) is structurally unreachable: entry into the only FSM state that evaluates this condition (IRQ_TAKEN) requires handle_irq, which is unconditionally 0 whenever nmi_mode_q==1 (cve2_controller.sv:301-302, explicit RTL comment: nested NMIs not supported). See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.}
+
+#   cve2_controller.sv:494 `if (handle_irq) begin` (inside IRQ_TAKEN) --
+#   its false arm ("All False Count") is a real branch-coverage miss, left
+#   DELIBERATELY UNEXCLUDED (user decision, 2026-08-12): this is
+#   `irq_withdrawn_in_taken` (see the `` `ifdef INC_ASSERT `` block further
+#   down and [[cve2-controller-assertions]] memory) -- an interrupt can be
+#   committed (DECODE->IRQ_TAKEN, handle_irq=1 at commit) and then
+#   withdrawn one cycle later, right as IRQ_TAKEN would perform the PC
+#   redirect. This is genuinely reachable and has been empirically
+#   confirmed once via cycle-accurate signal dump on
+#   corev_rand_interrupt_exception (see the memory entry for the exact
+#   timestamps) -- not dead code, just a rare, interrupt-noise-timing-
+#   dependent window that doesn't reproduce on every regression seed.
+#   Accepted as a documented gap rather than engineering interrupt-noise
+#   stimulus to force it reliably. Revisit only if there's a specific
+#   reason to chase deterministic reproduction. See
+#   docs/RTL-STATEMENT-COVERAGE-AUDIT.md.
+
+#   cve2_controller.sv:396 (SLEEP state's wfi wake condition)
+#   `(irq_nm_i || irq_pending_i || debug_req_i || debug_mode_q ||
+#   debug_single_step_i)` -- the `debug_single_step_i_1` FEC row (this term
+#   sensitized to 1, all others 0) is structurally unreachable, same
+#   "dead, not untested" category as the NMI row above. Reaching this line
+#   at all requires a `wfi` to have already completed the FLUSH -> WAIT_SLEEP
+#   -> SLEEP transition. But whenever `debug_single_step_i` (dcsr.step) is
+#   1, `do_single_step_d` (line 276) goes high the moment `wfi` first
+#   becomes `instr_valid_i` (in DECODE, before the special_req-triggered
+#   move to FLUSH), so `enter_debug_mode_prio_q` (line 287's registered
+#   form) is already 1 by the time FLUSH actually processes the `wfi` --
+#   and line 693's `if (enter_debug_mode_prio_q && ...) ctrl_fsm_ns =
+#   DBG_TAKEN_IF;` runs *after* (overrides) the `wfi_insn` branch's
+#   `ctrl_fsm_ns = WAIT_SLEEP` (line 675) in the same always_comb block,
+#   same cycle. So a single-stepped `wfi` is redirected straight back to
+#   debug mode and never actually reaches WAIT_SLEEP/SLEEP -- matching
+#   `tests/programs/custom/debug_test/single_step.S`'s own comment ("we are
+#   single stepping, WFI should complete as NOP"). Confirmed two ways: the
+#   RTL trace above, and empirically -- `debug_test` already exercises
+#   exactly this scenario (single-step directly over a `wfi`, `single_step.S`
+#   line 63) and still leaves this row at 0 hits even though line 396 itself
+#   is reached (via ordinary, non-single-stepped `wfi` wake-ups elsewhere in
+#   the same test). The other 4 terms of this condition are genuinely
+#   reachable and already covered -- only this one row is excluded. See
+#   docs/RTL-STATEMENT-COVERAGE-AUDIT.md.
+coverage exclude -du cve2_controller -feccondrow 396 10 -comment {debug_single_step_i sensitized (all other wake terms 0) while in SLEEP is structurally unreachable: a single-stepped wfi always re-enters debug mode via enter_debug_mode_prio_q (cve2_controller.sv:693) before it can complete the FLUSH->WAIT_SLEEP->SLEEP transition, so debug_single_step_i can never be the sole wake reason once SLEEP is actually reached. See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.}
+
+#   ctrl_fsm_cs FSM transitions: <STATE> -> RESET (all 9 non-RESET states).
+#   NOT dead code -- rst_ni is a real async input (see the `if (!rst_ni)`
+#   branch of update_regs, line 734) that can legitimately drop while the
+#   controller is in any state; these edges are genuinely reachable, just
+#   untested by the current suite (every test only resets once, at t=0,
+#   before the FSM has left RESET -- none exercise a mid-run reset).
+#   Excluded per explicit user decision (2026-08-10) to accept this as an
+#   untested stimulus gap rather than build new reset-injection test
+#   infrastructure right now. See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.
+set CTRL_FSM_RESET_TRANS_COMMENT {rst_ni can legitimately drop from any controller state -- not dead code, an accepted untested-stimulus gap (mid-run reset injection). See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.}
+coverage exclude -du cve2_controller -ftrans ctrl_fsm_cs {BOOT_SET->RESET} -comment $CTRL_FSM_RESET_TRANS_COMMENT
+coverage exclude -du cve2_controller -ftrans ctrl_fsm_cs {FIRST_FETCH->RESET} -comment $CTRL_FSM_RESET_TRANS_COMMENT
+coverage exclude -du cve2_controller -ftrans ctrl_fsm_cs {WAIT_SLEEP->RESET} -comment $CTRL_FSM_RESET_TRANS_COMMENT
+coverage exclude -du cve2_controller -ftrans ctrl_fsm_cs {SLEEP->RESET} -comment $CTRL_FSM_RESET_TRANS_COMMENT
+coverage exclude -du cve2_controller -ftrans ctrl_fsm_cs {DBG_TAKEN_IF->RESET} -comment $CTRL_FSM_RESET_TRANS_COMMENT
+coverage exclude -du cve2_controller -ftrans ctrl_fsm_cs {IRQ_TAKEN->RESET} -comment $CTRL_FSM_RESET_TRANS_COMMENT
+coverage exclude -du cve2_controller -ftrans ctrl_fsm_cs {DECODE->RESET} -comment $CTRL_FSM_RESET_TRANS_COMMENT
+coverage exclude -du cve2_controller -ftrans ctrl_fsm_cs {FLUSH->RESET} -comment $CTRL_FSM_RESET_TRANS_COMMENT
+coverage exclude -du cve2_controller -ftrans ctrl_fsm_cs {DBG_TAKEN_ID->RESET} -comment $CTRL_FSM_RESET_TRANS_COMMENT
+
+# cve2_multdiv_fast
+# =================
+#
+#   md_state_q (divider FSM) transitions: <STATE> -> MD_IDLE, for all 5
+#   non-MD_IDLE states. Same pattern/rationale as ctrl_fsm_cs above: NOT
+#   dead code -- `md_state_q <= MD_IDLE;` sits inside the `if (!rst_ni)`
+#   branch (line 99), so rst_ni dropping mid-divide is a real, reachable
+#   scenario, just untested by the current suite. Excluded per the same
+#   explicit user decision (2026-08-10). See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.
+#
+#   RESOLVED 2026-08-12 (was previously left unexcluded as "ambiguous",
+#   2026-08-10): mult_state_q (the multiply FSM in the same file/instance)
+#   has its own single miss, ALBH->ALBL, which is the exact same
+#   async-reset-artifact pattern as md_state_q above -- it just wasn't
+#   obviously so before, since this FSM resets into a real, named
+#   functional state (ALBL) rather than a dedicated RESET/MD_IDLE-style
+#   value. Confirmed via RTL trace: ALBH's own case-arm body (line 313)
+#   unconditionally sets mult_state_d = AHBL -- there is no functional
+#   path where ALBH transitions directly to ALBL. The only way to produce
+#   this edge is rst_ni dropping while in ALBH (`mult_state_q <= ALBL;`,
+#   line 362, inside the async `if (!rst_ni)` branch), which Questa's FSM
+#   extractor models as an implicit edge from every state to the reset
+#   value. Same accepted-gap category and same explicit user decision as
+#   every other reset-transition exclusion in this file. See
+#   docs/RTL-STATEMENT-COVERAGE-AUDIT.md.
+set MD_FSM_RESET_TRANS_COMMENT {rst_ni can legitimately drop mid-divide -- not dead code, an accepted untested-stimulus gap (mid-run reset injection). See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.}
+coverage exclude -du cve2_multdiv_fast -ftrans md_state_q {MD_ABS_A->MD_IDLE} -comment $MD_FSM_RESET_TRANS_COMMENT
+coverage exclude -du cve2_multdiv_fast -ftrans md_state_q {MD_ABS_B->MD_IDLE} -comment $MD_FSM_RESET_TRANS_COMMENT
+coverage exclude -du cve2_multdiv_fast -ftrans md_state_q {MD_COMP->MD_IDLE} -comment $MD_FSM_RESET_TRANS_COMMENT
+coverage exclude -du cve2_multdiv_fast -ftrans md_state_q {MD_LAST->MD_IDLE} -comment $MD_FSM_RESET_TRANS_COMMENT
+coverage exclude -du cve2_multdiv_fast -ftrans md_state_q {MD_CHANGE_SIGN->MD_IDLE} -comment $MD_FSM_RESET_TRANS_COMMENT
+coverage exclude -du cve2_multdiv_fast -ftrans gen_mult_fast/mult_state_q {ALBH->ALBL} -comment {rst_ni can legitimately drop mid-multiply -- not dead code, an accepted untested-stimulus gap (mid-run reset injection), same as the md_state_q transitions above. Note the FSM variable needs the gen_mult_fast/ generate-block qualifier here (unlike md_state_q, which isn't inside a generate block) -- confirmed via a -viewcov dry run after the bare "mult_state_q" form silently matched nothing. See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.}
+
+
+# To review:
+# coverage exclude -du cve2_if_stage -linerange 430 448
+
+# cve2_decoder
+# ============
+#
+#   Unreachable default cases: instr[14:12]/instr_alu[14:12] funct3 dispatch
+#   is exhaustive over 3 bits (see docs/RTL-DEAD-DEFAULT-CASES.md). Previously
+#   line 448 was mistakenly excluded under -du cve2_if_stage, which is a
+#   297-line file -- that exclusion was a silent no-op.
+#
+#   line 439 (illegal_insn = 1'b1;, inside the 5'b0_0001/unshfl case item's
+#   `if (instr[26]==1'b0) ... else` at line 436) is unreachable: this whole
+#   case(instr[31:27]) block is only entered from the `else` of the outer
+#   `if (instr[26]) begin // fsri ... end else begin` at line 404-406, which
+#   already constrains instr[26]==1'b0 for everything inside it -- so the
+#   inner `else` at 436 (instr[26]==1'b1) can never be taken. Previously
+#   excluded (correctly identified, wrong DU) under -du cve2_if_stage.
+#   See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.
+coverage exclude -du cve2_decoder -linerange 439 448 930
+
+#   Branch-level exclusion for the same finding above, added 2026-08-12
+#   while auditing branch-coverage holes: the statement exclusion at 439
+#   never covered the `if` decision itself, which Questa associates with
+#   line 438 (the `end else begin` of the inner `if (instr[26]==1'b0)`,
+#   itself already inside the outer instr[26]==1'b0-only scope). Verified
+#   via -viewcov dry run that this removes only the dead miss bin (264
+#   bins/254 hits/10 misses -> 263/254/9), no side effect on the sibling
+#   (legitimate, hit) true-arm bin -- same "explicit else on its own line
+#   excludes surgically" shape as cve2_alu.sv:284 found in the same
+#   session. See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.
+coverage exclude -du cve2_decoder -linerange 438 -code b -comment {Unreachable: this if (instr[26]==1'b0) is nested inside an outer scope that already constrains instr[26]==1'b0 for everything inside it (cve2_decoder.sv:404-406), so this inner else (instr[26]==1'b1) can never be taken. Same root cause as the line-439 statement exclusion above. See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.}
+
+# cve2_tracer
+# ===========
+#
+#   Excluded entirely. This is a simulation-only instruction/CSR disassembler
+#   for the trace log, not DUT behavior: almost all of its statement misses
+#   are individual entries in a large CSR-address-to-name / instruction-
+#   mnemonic-to-string lookup table (implemented-but-untested CSRs, CSR names
+#   for S-mode/H-mode/legacy addresses only reachable via illegal CSR
+#   accesses, RV32B mnemonics only reachable via illegal RV32B encodings).
+#   None of it is dead code -- every entry is reachable given the right raw
+#   instruction bits -- but it's an inherently large, sparse decode space
+#   that isn't a meaningful coverage-quality signal for the DUT itself. See
+#   docs/RTL-STATEMENT-COVERAGE-AUDIT.md.
+coverage exclude -du cve2_tracer -comment {Simulation-only disassembler for the trace log, not DUT behavior}
+
+# cve2_cs_registers
+# =================
+#
+#   The UmodeEnabled=0 exclusions for this file (mstatus_d.mprv = 1'b0 at
+#   line 687, plus the mstatus_d.mpp/dcsr_d.prv vs PRIV_LVL_U conditions at
+#   540/568/685) live in the UmodeEnabled-gated block near the bottom of
+#   this file, alongside the matching cve2_controller exclusions -- same
+#   root cause, single toggle point. See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.
+#
+#   PMPCFG0-3/PMPADDR0-15 CSR read case items (361-384): a prior exclusion
+#   here (-linerange 372-395) was WRONG on two counts, found 2026-08-12 while
+#   investigating branch-coverage holes. (1) Its dead-code premise doesn't
+#   hold: the read logic is NOT gated by a guard before the case -- the
+#   `unique case (csr_addr_i)` runs unconditionally (csr_addr = csr_addr_i
+#   directly, no legalization), and the `if (!PMPEnable) ... illegal_csr =
+#   1'b1;` override sits AFTER `endcase` (lines 478-486), not wrapping it.
+#   So any real CSR instruction targeting a PMP address DOES select these
+#   case items and execute the read -- illegal_csr is only forced true
+#   afterward, meaning the access still traps, but the RTL line itself is
+#   reachable. Same category as the already-untouched illegal_csr override
+#   line, which this file's comment always correctly called "genuinely
+#   reachable... untested", not dead. (2) Its line range was also stale --
+#   372-395 doesn't even cover the real PMPCFG0-3/PMPADDR0-2 case items
+#   (361-371), and instead wrongly swallowed CSR_DCSR/CSR_DPC/CSR_DSCRATCH0's
+#   `begin` blocks (386-395+), silently hiding real, well-tested code from
+#   the coverage metric instead of counting it as covered. Closed with real
+#   stimulus instead of a corrected exclusion: illegal_instr_test.S gained
+#   one hand-built `csrrw x0,<pmp-csr>,x0` per PMPCFG0-3/PMPADDR0-15 (20
+#   entries). See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.
+
+#   Lines 1460-1579 (the whole `ifdef RVFI ... endif` block) are RVFI
+#   (RISC-V Formal Interface) monitoring plumbing: structs/wires that
+#   reformat already-existing DUT state (mstatus_q.mie, mip.irq_software,
+#   etc.) for the RVFI monitor/co-simulation interface, plus the
+#   RVFI_CONNECT-macro-generated per-CSR read/write-mask tracking
+#   (mstatus/mie/mip/misa/mtvec/mepc/mcause/mtval/mstatush/dcsr/dpc/
+#   dscratch0/dscratch1/mscratch). `RVFI` is only ever defined via
+#   `+define+CV32E20_RVFI+RVFI` in sim/uvmt/Makefile -- a verification-
+#   testbench-only compile flag, never present for synthesis. Same
+#   category as the cve2_tracer exclusion above: simulation/monitoring-
+#   only, not DUT behavior. Originally investigated as a genuine "thin
+#   CSR software-write coverage" gap (the repeated `RVFI_CONNECT`
+#   write-mask condition never going true for MIP/MISA/MTVEC/MEPC/MCAUSE/
+#   MTVAL/MSTATUSH/DSCRATCH1) before the ifdef boundary was noticed --
+#   see docs/RTL-STATEMENT-COVERAGE-AUDIT.md.
+coverage exclude -du cve2_cs_registers -linerange 1460-1579 -comment {RVFI (RISC-V Formal Interface) monitoring plumbing -- only compiled for the verification testbench (+define+RVFI in sim/uvmt/Makefile), never for synthesis. Not DUT behavior.}
+
+#   cve2_core.sv:1152/1154/1156 -- `instr_valid_id | ~captured_valid`, used to
+#   select live vs. captured mip/nmi/debug_req values for the RVFI ext-stage
+#   tracking pipeline. In each, FEC Row 2 (instr_valid_id sensitized true
+#   while captured_valid==1) is structurally unreachable: instr_valid_id is
+#   if_stage_i.instr_valid_id_q (cve2_core.sv:328), and captured_valid can
+#   only be *set* while instr_valid_id==0 (line 1119: `~instr_valid_id & ...`).
+#   captured_valid is *cleared* on exactly the edge that
+#   if_stage_i.instr_valid_id_d is 1 (line 1133) -- the same signal that
+#   drives instr_valid_id_q to 1 on that edge (cve2_if_stage.sv:244-245). So
+#   the only transition of instr_valid_id 0->1 always coincides with
+#   captured_valid being cleared to 0 on that same edge: instr_valid_id==1
+#   and captured_valid==1 can never hold simultaneously. Confirmed empirically
+#   too -- Row 1 of the same condition hits repeatedly across the regression
+#   (including heavy interrupt/debug/nmi tests) while Row 2 never hits once.
+#   See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.
+coverage exclude -du cve2_core -feccondrow 1152 2 -comment {instr_valid_id==1 while captured_valid==1 is structurally unreachable: both are driven from if_stage_i.instr_valid_id_d/_q, and the only 0->1 transition of instr_valid_id coincides with captured_valid being cleared on the same edge. See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.}
+coverage exclude -du cve2_core -feccondrow 1154 2 -comment {instr_valid_id==1 while captured_valid==1 is structurally unreachable: both are driven from if_stage_i.instr_valid_id_d/_q, and the only 0->1 transition of instr_valid_id coincides with captured_valid being cleared on the same edge. See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.}
+coverage exclude -du cve2_core -feccondrow 1156 2 -comment {instr_valid_id==1 while captured_valid==1 is structurally unreachable: both are driven from if_stage_i.instr_valid_id_d/_q, and the only 0->1 transition of instr_valid_id coincides with captured_valid being cleared on the same edge. See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.}
+
+#   Exclude coverage for ID stage when CV-X-IF is disabled
+if {!$XInterface} {
+    coverage exclude -du cve2_id_stage -linerange 494 -comment $CV_XIF_DISABLED_COMMENT
+    coverage exclude -du cve2_id_stage -linerange 829-832 -comment $CV_XIF_DISABLED_COMMENT
+
+    #   cve2_controller.sv:453,472,478 -- `ctrl_fsm_ns = xif_scoreboard_busy_i
+    #   ? DECODE : <FLUSH|DBG_TAKEN_IF|IRQ_TAKEN>;`. xif_scoreboard_busy_i is
+    #   fed from cve2_id_stage.sv's scoreboard_busy, which the no_gen_xif
+    #   generate branch (entered whenever XInterface is disabled,
+    #   cve2_id_stage.sv:388) hardwires to `1'b0` -- so the DECODE arm of
+    #   each ternary can never be taken. Found 2026-08-12 auditing
+    #   branch-coverage holes. See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.
+    coverage exclude -du cve2_controller -linerange 453 472 478 -code b -comment $CV_XIF_DISABLED_COMMENT
+}
+
+# Exclude coverage for RVB (Bitmanip) extension
+if {!$RVB} {
+    coverage exclude -du cve2_alu -linerange 88-90 285 288-289 308-315 319 376-378 1342 1345 1355 1359 1363 1366 1369-1378 1381-1382 1385 1388 1391-1392 -comment $RVB_DISABLED_COMMENT
+
+    #   Branch-level RVB-disabled dead code found 2026-08-12 while auditing
+    #   cve2_alu's branch-coverage holes (the -linerange block above only
+    #   ever targeted statement coverage for a different, smaller set of
+    #   lines -- these are a genuinely separate, much larger set of ALU
+    #   case-item/if-branch decision points never previously excluded at
+    #   -code b). All confirmed via the decoder: every RV32B-only ALU
+    #   opcode (ALU_MIN/MINU/MAX/MAXU, ALU_SH1ADD/SH2ADD/SH3ADD,
+    #   ALU_XNOR/ORN/ANDN, ALU_SLO/SRO, ALU_CLZ/CTZ, ALU_PACK/PACKH) is only
+    #   ever assigned to alu_operator_o inside an `if (RV32B != RV32BNone)`
+    #   (or narrower RV32BOTEarlGrey/RV32BFull) guard in cve2_decoder.sv
+    #   (lines 820, 1008-1024 for the OP-immediate/-register paths) -- with
+    #   RV32B hardcoded to RV32BNone, alu_operator_i can never actually take
+    #   any of these values, so every case item selecting on them is
+    #   structurally unreachable, not just untested. Likewise bfp_op
+    #   (line 267) and shift_sbmode (line 294) are each an explicit
+    #   `(RV32B != RV32BNone) ? ... : 1'b0` ternary -- permanently 0 here --
+    #   so their own `if` branches (284, 318) are dead, and
+    #   bwlogic_op_b_negate (permanently 0 once XNOR/ORN/ANDN/CMIX are all
+    #   dead, lines 375-378) makes line 383's ternary true-arm dead too.
+    #
+    #   Verified via a -viewcov dry run before applying: several of these
+    #   share a case-statement line with an already-covered, live opcode
+    #   (e.g. line 1325 lists `ALU_XOR, ALU_XNOR,` together -- XOR is hit,
+    #   XNOR is dead). Questa's -code b exclusion removes a line's branch
+    #   bins as one unit (no per-arm granularity for grouped case items,
+    #   same limitation found this session excluding cve2_cs_registers'
+    #   UmodeEnabled branches) -- so excluding these lines also drops the
+    #   sibling live opcode's own separately-tracked hit bin. Confirmed this
+    #   is a clean consolidation, not a real loss of signal: XOR/OR/AND
+    #   (lines 1325-1327) and the shift_sbmode/bwlogic_op_b_negate implicit
+    #   false-arms (318, 383) were all unambiguously covered already. Lines
+    #   284's `if/else` has an explicit `end else begin` on its own line
+    #   (286), so unlike the others it excluded surgically -- only the dead
+    #   true arm was removed, line 286's hit stayed a separately-tracked bin.
+    #   Full before/after: 91 bins/60 hits/31 misses -> 55/55/0 (100%).
+    #   See docs/RTL-STATEMENT-COVERAGE-AUDIT.md.
+    coverage exclude -du cve2_alu -linerange 72 73 76 77 78 126 127 165 167 -code b -comment $RVB_DISABLED_COMMENT
+    coverage exclude -du cve2_alu -linerange 284 318 375 383 -code b -comment $RVB_DISABLED_COMMENT
+    coverage exclude -du cve2_alu -linerange 1325 1326 1327 1332 1333 1339 1354 1358 1362 -code b -comment $RVB_DISABLED_COMMENT
+
+    #   line 171: (use_rs3_q & ~instr_first_cycle_i) ? instr_rs3 : instr_rs1.
+    #   use_rs3_q is tied combinationally to use_rs3_d via gen_no_rs3_flop
+    #   when RV32B==RV32BNone (line 164), and every `use_rs3_d = 1'b1;`
+    #   assignment (CMIX/CMOV/FSL/FSR decode) sits inside an
+    #   `if (RV32B != RV32BNone)` guard that can never be entered here --
+    #   so use_rs3_q is permanently 0 and both input terms of this
+    #   condition are structurally masked. Found while verifying where
+    #   condition-coverage holes cluster; same RVB-disabled dead-code
+    #   family as the cve2_alu exclusion above. See
+    #   docs/RTL-STATEMENT-COVERAGE-AUDIT.md.
+    coverage exclude -du cve2_decoder -linerange 171 -comment $RVB_DISABLED_COMMENT
+}
+
+# Exclude coverage for U-mode support (UmodeEnabled hardcoded to 0)
+if {!$UmodeEnabled} {
+    #   cve2_cs_registers.sv:
+    #   - line 687 (mstatus_d.mprv = 1'b0;, inside MRET's
+    #     `if (mstatus_q.mpp != PRIV_LVL_M)` at 685): unreachable statement,
+    #     since mpp can never be non-M with U-mode disabled. Unscoped (no
+    #     genuinely-live coverage type shares this line).
+    #   - line 685's own condition (mstatus_q.mpp != PRIV_LVL_M): the `if`
+    #     itself is genuinely reachable/hit every MRET (mpp==M side), only
+    #     its true branch (mpp!=M) is dead -- excluded -code c since 2026-08-11.
+    #   - lines 540, 568 (mstatus_d.mpp/dcsr_d.prv vs PRIV_LVL_U checks,
+    #     `... && (umode_control ~& (... == PRIV_LVL_U))`): umode_control is
+    #     permanently 0 and the PRIV_LVL_U comparisons can never be true --
+    #     condition-only, same reasoning as line 685.
+    #     NOTE (2026-08-11): these three -linerange targets were previously
+    #     687/687/(542 570) -- stale by exactly 2 lines, silently missing
+    #     their intended targets (Questa doesn't error on a -linerange that
+    #     matches no excludable item at that line). Found via a design-wide
+    #     cov_holes -code c sweep: this file's 5 condition misses were
+    #     literally the ones this block was already meant to exclude. Cause
+    #     of the 2-line drift not investigated (likely upstream RTL edits
+    #     after this block was written); fix was to re-point at current
+    #     line numbers, verified against the live RTL file before applying.
+    #   - BRANCH-level exclusions added 2026-08-12 for the same UmodeEnabled=0
+    #     root cause, previously left uncounted on purpose ("the line's real
+    #     statement/branch coverage stays counted") but explicitly requested
+    #     closed this session:
+    #       * line 685 (`if (mstatus_q.mpp != PRIV_LVL_M)`): true branch dead,
+    #         mpp forced back to M by every software write (line 535's write-
+    #         side legalization, `& umode_control`) and by MRET's own
+    #         legalization here.
+    #       * line 705 (`mstatus_d.mpp = umode_control ? PRIV_LVL_U :
+    #         PRIV_LVL_M;`): the PRIV_LVL_U arm is dead, umode_control
+    #         permanently 0.
+    #       * line 725 (`assign priv_mode_lsu_o = mstatus_q.mprv ? ... :
+    #         priv_lvl_q;`): the mstatus_q.mprv arm is dead -- mprv can never
+    #         become 1, since every software write to it is masked
+    #         (`csr_wdata_int[...] & umode_control`, line 535) and the only
+    #         RTL path that could set it (line 686, `mstatus_d.mprv = 1'b0;`)
+    #         is itself inside the already-dead line-685 `if`.
+    #     Questa's -code b exclusion for a simple if/ternary removes the
+    #     whole branch (both arms) as one unit -- no per-arm granularity like
+    #     -feccondrow gives for conditions -- so the already-covered false/
+    #     M-mode arm's bin is removed too, not just the dead true arm. Net
+    #     effect confirmed via a -viewcov dry run before applying: cs_registers_i
+    #     branches 257/260 (3 misses) -> 254/254 (100%, clean, no side effects
+    #     on any other line).
+    #   NOTE (2026-08-12): this -linerange target was previously 687 -- off
+    #   by exactly 1 line (the statement itself is at 686; 687 is just the
+    #   closing `end`), silently missing its target this whole time. Found
+    #   via a design-wide statement-coverage sweep: this was the ONLY
+    #   statement-level miss left in the entire design. Fixed by re-pointing
+    #   at the correct line, verified against the live RTL file.
+    coverage exclude -du cve2_cs_registers -linerange 686 -comment $UMODE_DISABLED_COMMENT
+    coverage exclude -du cve2_cs_registers -linerange 685 -code c -comment $UMODE_DISABLED_COMMENT
+    coverage exclude -du cve2_cs_registers -linerange 540 568 -code c -comment $UMODE_DISABLED_COMMENT
+    coverage exclude -du cve2_cs_registers -linerange 685 -code b -comment $UMODE_DISABLED_COMMENT
+    coverage exclude -du cve2_cs_registers -linerange 705 -code b -comment $UMODE_DISABLED_COMMENT
+    coverage exclude -du cve2_cs_registers -linerange 725 -code b -comment $UMODE_DISABLED_COMMENT
+
+    #   cve2_controller.sv: priv_mode_i (fed from cs_registers' permanently-M
+    #   priv_lvl_q) is permanently PRIV_LVL_M, so `priv_mode_i == PRIV_LVL_M`
+    #   (lines 292, 614) can never evaluate false and
+    #   `priv_mode_i == PRIV_LVL_U` (line 293) can never evaluate true --
+    #   condition-only, same reasoning as above.
+    coverage exclude -du cve2_controller -linerange 292 293 614 -code c -comment $UMODE_DISABLED_COMMENT
+
+    #   Branch-level exclusions for the same finding, added 2026-08-12 while
+    #   auditing branch-coverage holes (same "-code c scope gap" pattern
+    #   found this session on cs_registers_i/decoder_i): lines 292-294 are
+    #   the nested `ebreak_into_debug = priv_mode_i==PRIV_LVL_M ? ... :
+    #   priv_mode_i==PRIV_LVL_U ? ... : 1'b0;` ternary -- since the outer
+    #   `priv_mode_i==PRIV_LVL_M` term is always true, the entire inner
+    #   ternary (293's own condition and 294's default) is never evaluated.
+    #   Line 615 is `EXC_CAUSE_ECALL_UMODE`, the same permanently-dead U-mode
+    #   arm as line 293. Verified via -viewcov dry run alongside the
+    #   XInterface/one-hot-default exclusions below: controller_i branches
+    #   86/77/9 -> 74/73/1 (only the genuine, real irq_withdrawn_in_taken
+    #   miss at line 494 remains -- see below).
+    coverage exclude -du cve2_controller -linerange 292-294 -code b -comment $UMODE_DISABLED_COMMENT
+    coverage exclude -du cve2_controller -linerange 615 -code b -comment $UMODE_DISABLED_COMMENT
+}
+
+coverage save -onexit -testname ${TEST} ${TEST}.ucdb

--- a/sim/tools/vsim/coverage_extract.tcl
+++ b/sim/tools/vsim/coverage_extract.tcl
@@ -1,0 +1,34 @@
+# TCL script to extract TRL5 coverage metrics from UCDB file
+# Usage: vcover load <ucdb_file> -test dummy -run <this_script>
+# Sets the instance path via COV_INSTANCE environment variable
+
+# Load the UCDB file (already loaded by vcover command)
+# database open -in merged.ucdb  # Not needed as vcover loads it
+
+# Get coverage metrics for the specific instance
+set instance "$::env(COV_INSTANCE)"
+
+# Statement/Line Coverage (Questa calls this "statement" coverage)
+set stmt_coverage [coverage get -hier $instance -metric statement max]
+
+# Branch Coverage
+set branch_coverage [coverage get -hier $instance -metric branch max]
+
+# Condition Coverage
+set condition_coverage [coverage get -hier $instance -metric condition max]
+
+# FSM State Coverage (using fstate metric)
+set fsm_state_coverage [coverage get -hier $instance -metric fstate max]
+
+# FSM Transition Coverage (using ftrans metric)
+set fsm_transition_coverage [coverage get -hier $instance -metric ftrans max]
+
+# Output results in a machine-readable format
+puts "STATEMENT:$stmt_coverage"
+puts "BRANCH:$branch_coverage"
+puts "CONDITION:$condition_coverage"
+puts "FSM_STATE:$fsm_state_coverage"
+puts "FSM_TRANSITION:$fsm_transition_coverage"
+
+# Close the database (not strictly needed as vcover will exit)
+# database close

--- a/tb/uvmt/uvmt_cv32e20_dut_wrap.sv
+++ b/tb/uvmt/uvmt_cv32e20_dut_wrap.sv
@@ -184,7 +184,7 @@ module uvmt_cv32e20_dut_wrap #(
          .irq_timer_i            ( irq_uvma[7]                    ),
          .irq_external_i         ( irq_uvma[11]                   ),
          .irq_fast_i             ( irq_uvma[31:16]                ),
-         .irq_nm_i               ( 1'b0 /*irq_uvma[0]*/           ), // TODO: non-maskeable interrupt
+         .irq_nm_i               ( irq_uvma[0]                    ), // non-maskable interrupt
 
   // Debug Interface
          .debug_req_i             ( debug_req_uvma ),

--- a/tb/uvmt/uvmt_cv32e20_imperas_dv_wrap.sv
+++ b/tb/uvmt/uvmt_cv32e20_imperas_dv_wrap.sv
@@ -20,10 +20,6 @@
 `ifndef __UVMT_CV32E20_IMPERAS_DV_WRAP_SV__
 `define __UVMT_CV32E20_IMPERAS_DV_WRAP_SV__
 
-`define DUT_PATH dut_wrap.cv32e20_top_i
-`define RVFI_IF  `DUT_PATH
-`define DUT_CORE_PATH dut_wrap.cv32e20_top_i.u_cve2_top.u_cve2_core
-
 `define STRINGIFY(x) `"x`"
 
 ////////////////////////////////////////////////////////////////////////////
@@ -99,6 +95,10 @@ module uvmt_cv32e20_imperas_dv_wrap
     (
         rvviTrace  rvvi // RVVI SystemVerilog Interface
     );
+
+`define DUT_PATH dut_wrap.cv32e20_top_i
+`define RVFI_IF  `DUT_PATH
+`define DUT_CORE_PATH dut_wrap.cv32e20_top_i.u_cve2_top.u_cve2_core
 
     trace2log       idv_trace2log(rvvi);
 

--- a/tests/programs/custom/csr_instr_asm/csr_instr_asm.S
+++ b/tests/programs/custom/csr_instr_asm/csr_instr_asm.S
@@ -6282,6 +6282,167 @@ test_done:
     sw a1,0(a0)
     sw a1,0(a0)
 
+# Coverage-closing block, added 2026-08-12: exercise legal but previously
+# untested CSR reads/writes in cve2_cs_registers.sv's read/write case
+# statements (MCONFIGPTR/MSTATUSH/MENVCFG(H)/MCOUNTEREN/SECURESEED reads;
+# unimplemented-but-architecturally-legal HPM counters/events 13-31
+# (MHPMCounterNum=10, read-as-zero/write-inert for indices >=10); the
+# 64-bit HPM counters' upper-word CSRs (*H, both implemented 3-12 and
+# unimplemented 13-31); MTVAL and direct HPM-counter writes). None of
+# these are illegal_csr -- all reach their case item and (for reads)
+# return a real or constant-zero value; see docs/RTL-STATEMENT-COVERAGE-AUDIT.md.
+csr_coverage_closing:
+    # Reads (csrrs x5,<csr>,x0 -- rs1=x0 so no side effect, real read into x5)
+    csrrs x5, 0x323, x0    # mhpmevent3
+    csrrs x5, 0x324, x0    # mhpmevent4
+    csrrs x5, 0x325, x0    # mhpmevent5
+    csrrs x5, 0x326, x0    # mhpmevent6
+    csrrs x5, 0x327, x0    # mhpmevent7
+    csrrs x5, 0x328, x0    # mhpmevent8
+    csrrs x5, 0x329, x0    # mhpmevent9
+    csrrs x5, 0x32A, x0    # mhpmevent10
+    csrrs x5, 0x32B, x0    # mhpmevent11
+    csrrs x5, 0x32C, x0    # mhpmevent12
+    csrrs x5, 0xF15, x0    # mconfigptr
+    csrrs x5, 0x310, x0    # mstatush
+    csrrs x5, 0x30A, x0    # menvcfg
+    csrrs x5, 0x31A, x0    # menvcfgh
+    csrrs x5, 0x306, x0    # mcounteren
+    csrrs x5, 0x7C1, x0    # secureseed
+    csrrs x5, 0x32D, x0    # mhpmevent13
+    csrrs x5, 0x32E, x0    # mhpmevent14
+    csrrs x5, 0x32F, x0    # mhpmevent15
+    csrrs x5, 0x330, x0    # mhpmevent16
+    csrrs x5, 0x331, x0    # mhpmevent17
+    csrrs x5, 0x332, x0    # mhpmevent18
+    csrrs x5, 0x333, x0    # mhpmevent19
+    csrrs x5, 0x334, x0    # mhpmevent20
+    csrrs x5, 0x335, x0    # mhpmevent21
+    csrrs x5, 0x336, x0    # mhpmevent22
+    csrrs x5, 0x337, x0    # mhpmevent23
+    csrrs x5, 0x338, x0    # mhpmevent24
+    csrrs x5, 0x339, x0    # mhpmevent25
+    csrrs x5, 0x33A, x0    # mhpmevent26
+    csrrs x5, 0x33B, x0    # mhpmevent27
+    csrrs x5, 0x33C, x0    # mhpmevent28
+    csrrs x5, 0x33D, x0    # mhpmevent29
+    csrrs x5, 0x33E, x0    # mhpmevent30
+    csrrs x5, 0x33F, x0    # mhpmevent31
+    csrrs x5, 0xB0D, x0    # mhpmcounter13
+    csrrs x5, 0xB0E, x0    # mhpmcounter14
+    csrrs x5, 0xB0F, x0    # mhpmcounter15
+    csrrs x5, 0xB10, x0    # mhpmcounter16
+    csrrs x5, 0xB11, x0    # mhpmcounter17
+    csrrs x5, 0xB12, x0    # mhpmcounter18
+    csrrs x5, 0xB13, x0    # mhpmcounter19
+    csrrs x5, 0xB14, x0    # mhpmcounter20
+    csrrs x5, 0xB15, x0    # mhpmcounter21
+    csrrs x5, 0xB16, x0    # mhpmcounter22
+    csrrs x5, 0xB17, x0    # mhpmcounter23
+    csrrs x5, 0xB18, x0    # mhpmcounter24
+    csrrs x5, 0xB19, x0    # mhpmcounter25
+    csrrs x5, 0xB1A, x0    # mhpmcounter26
+    csrrs x5, 0xB1B, x0    # mhpmcounter27
+    csrrs x5, 0xB1C, x0    # mhpmcounter28
+    csrrs x5, 0xB1D, x0    # mhpmcounter29
+    csrrs x5, 0xB1E, x0    # mhpmcounter30
+    csrrs x5, 0xB1F, x0    # mhpmcounter31
+    csrrs x5, 0xB80, x0    # mcycleh
+    csrrs x5, 0xB82, x0    # minstreth
+    csrrs x5, 0xB83, x0    # mhpmcounter3h
+    csrrs x5, 0xB84, x0    # mhpmcounter4h
+    csrrs x5, 0xB85, x0    # mhpmcounter5h
+    csrrs x5, 0xB86, x0    # mhpmcounter6h
+    csrrs x5, 0xB87, x0    # mhpmcounter7h
+    csrrs x5, 0xB88, x0    # mhpmcounter8h
+    csrrs x5, 0xB89, x0    # mhpmcounter9h
+    csrrs x5, 0xB8A, x0    # mhpmcounter10h
+    csrrs x5, 0xB8B, x0    # mhpmcounter11h
+    csrrs x5, 0xB8C, x0    # mhpmcounter12h
+    csrrs x5, 0xB8D, x0    # mhpmcounter13h
+    csrrs x5, 0xB8E, x0    # mhpmcounter14h
+    csrrs x5, 0xB8F, x0    # mhpmcounter15h
+    csrrs x5, 0xB90, x0    # mhpmcounter16h
+    csrrs x5, 0xB91, x0    # mhpmcounter17h
+    csrrs x5, 0xB92, x0    # mhpmcounter18h
+    csrrs x5, 0xB93, x0    # mhpmcounter19h
+    csrrs x5, 0xB94, x0    # mhpmcounter20h
+    csrrs x5, 0xB95, x0    # mhpmcounter21h
+    csrrs x5, 0xB96, x0    # mhpmcounter22h
+    csrrs x5, 0xB97, x0    # mhpmcounter23h
+    csrrs x5, 0xB98, x0    # mhpmcounter24h
+    csrrs x5, 0xB99, x0    # mhpmcounter25h
+    csrrs x5, 0xB9A, x0    # mhpmcounter26h
+    csrrs x5, 0xB9B, x0    # mhpmcounter27h
+    csrrs x5, 0xB9C, x0    # mhpmcounter28h
+    csrrs x5, 0xB9D, x0    # mhpmcounter29h
+    csrrs x5, 0xB9E, x0    # mhpmcounter30h
+    csrrs x5, 0xB9F, x0    # mhpmcounter31h
+    # Writes (csrrw x0,<csr>,x0 -- op=WRITE regardless of rs1, writes 0, discards read)
+    csrrw x0, 0x343, x0    # mtval
+    csrrw x0, 0xB00, x0    # mcycle
+    csrrw x0, 0xB02, x0    # minstret
+    csrrw x0, 0xB03, x0    # mhpmcounter3
+    csrrw x0, 0xB04, x0    # mhpmcounter4
+    csrrw x0, 0xB05, x0    # mhpmcounter5
+    csrrw x0, 0xB06, x0    # mhpmcounter6
+    csrrw x0, 0xB07, x0    # mhpmcounter7
+    csrrw x0, 0xB08, x0    # mhpmcounter8
+    csrrw x0, 0xB09, x0    # mhpmcounter9
+    csrrw x0, 0xB0A, x0    # mhpmcounter10
+    csrrw x0, 0xB0B, x0    # mhpmcounter11
+    csrrw x0, 0xB0C, x0    # mhpmcounter12
+    csrrw x0, 0xB0D, x0    # mhpmcounter13
+    csrrw x0, 0xB0E, x0    # mhpmcounter14
+    csrrw x0, 0xB0F, x0    # mhpmcounter15
+    csrrw x0, 0xB10, x0    # mhpmcounter16
+    csrrw x0, 0xB11, x0    # mhpmcounter17
+    csrrw x0, 0xB12, x0    # mhpmcounter18
+    csrrw x0, 0xB13, x0    # mhpmcounter19
+    csrrw x0, 0xB14, x0    # mhpmcounter20
+    csrrw x0, 0xB15, x0    # mhpmcounter21
+    csrrw x0, 0xB16, x0    # mhpmcounter22
+    csrrw x0, 0xB17, x0    # mhpmcounter23
+    csrrw x0, 0xB18, x0    # mhpmcounter24
+    csrrw x0, 0xB19, x0    # mhpmcounter25
+    csrrw x0, 0xB1A, x0    # mhpmcounter26
+    csrrw x0, 0xB1B, x0    # mhpmcounter27
+    csrrw x0, 0xB1C, x0    # mhpmcounter28
+    csrrw x0, 0xB1D, x0    # mhpmcounter29
+    csrrw x0, 0xB1E, x0    # mhpmcounter30
+    csrrw x0, 0xB1F, x0    # mhpmcounter31
+    csrrw x0, 0xB80, x0    # mcycleh
+    csrrw x0, 0xB82, x0    # minstreth
+    csrrw x0, 0xB83, x0    # mhpmcounter3h
+    csrrw x0, 0xB84, x0    # mhpmcounter4h
+    csrrw x0, 0xB85, x0    # mhpmcounter5h
+    csrrw x0, 0xB86, x0    # mhpmcounter6h
+    csrrw x0, 0xB87, x0    # mhpmcounter7h
+    csrrw x0, 0xB88, x0    # mhpmcounter8h
+    csrrw x0, 0xB89, x0    # mhpmcounter9h
+    csrrw x0, 0xB8A, x0    # mhpmcounter10h
+    csrrw x0, 0xB8B, x0    # mhpmcounter11h
+    csrrw x0, 0xB8C, x0    # mhpmcounter12h
+    csrrw x0, 0xB8D, x0    # mhpmcounter13h
+    csrrw x0, 0xB8E, x0    # mhpmcounter14h
+    csrrw x0, 0xB8F, x0    # mhpmcounter15h
+    csrrw x0, 0xB90, x0    # mhpmcounter16h
+    csrrw x0, 0xB91, x0    # mhpmcounter17h
+    csrrw x0, 0xB92, x0    # mhpmcounter18h
+    csrrw x0, 0xB93, x0    # mhpmcounter19h
+    csrrw x0, 0xB94, x0    # mhpmcounter20h
+    csrrw x0, 0xB95, x0    # mhpmcounter21h
+    csrrw x0, 0xB96, x0    # mhpmcounter22h
+    csrrw x0, 0xB97, x0    # mhpmcounter23h
+    csrrw x0, 0xB98, x0    # mhpmcounter24h
+    csrrw x0, 0xB99, x0    # mhpmcounter25h
+    csrrw x0, 0xB9A, x0    # mhpmcounter26h
+    csrrw x0, 0xB9B, x0    # mhpmcounter27h
+    csrrw x0, 0xB9C, x0    # mhpmcounter28h
+    csrrw x0, 0xB9D, x0    # mhpmcounter29h
+    csrrw x0, 0xB9E, x0    # mhpmcounter30h
+    csrrw x0, 0xB9F, x0    # mhpmcounter31h
+
 # extraneous, manually added, store (write) and load (read)
 extra_store_load:
     li  x18, 0x12345678

--- a/tests/programs/custom/debug_test/debugger.S
+++ b/tests/programs/custom/debug_test/debugger.S
@@ -604,6 +604,18 @@ _debugger_end_continue:
     //lw t0, 0(a0)
     la a0, __debugger_stack_start
     csrr t0, 0x7b3
+    // Close csr_pipeline_flushes condition coverage (cve2_id_stage.sv:604):
+    // exercise the CLEAR-op form (csrrc, nonzero rs1 so it isn't reclassified
+    // to a plain read by cve2_decoder.sv:198-200) against dpc/dscratch1, the
+    // two debug CSRs no existing test issued a csrrc/csrrci against. Safe
+    // here specifically: dscratch1 has already been read out into the real
+    // t0 above (its CSR value is dead until the next debug entry's csrw
+    // overwrites it), and clearing dpc's bit 0 is a true no-op since dpc is
+    // always even (instruction alignment) -- t1 is about to be clobbered by
+    // the lw below regardless, so it's free to use as the clear mask.
+    li t1, 1
+    csrrc x0, dpc, t1
+    csrrc x0, dscratch1, t1
     lw   t1, 4(a0)
     lw   t2, 8(a0)
     lw   a1, 12(a0)

--- a/tests/programs/custom/illegal_instr_test/illegal_instr_test.S
+++ b/tests/programs/custom/illegal_instr_test/illegal_instr_test.S
@@ -47697,6 +47697,66 @@ main:
 .word(0x04008033) # p.abs   [31:25]==000_0010, [14:12]==000, [6:0]==011_0011
     nop
 .word(0x040080B3) # p.abs   [31:25]==000_0010, [14:12]==000, [6:0]==011_0011
+.word(0x2870D093) # orc.b [31:27]==0_0101,[26]=0,[24:20]==0_0111 (rs2=7), RV32B=None on this core -> illegal
+.word(0x74701073) # csrrw x0,mseccfg,x0 -- PMPEnable=0 on this core, so mseccfg (0x747) is always illegal_csr
+.half(0x4002) # c.lwsp x0,0(sp) -- RESERVED (rd==0), cve2_compressed_decoder.sv:221. u_sw_irq_handler correctly detects compressed illegal instrs and advances mepc by 2, not 4.
+.half(0x8002) # c.jr x0 -- RESERVED (rd==0), cve2_compressed_decoder.sv:233. Same category as the c.lwsp entry above; only reached before via corev-dv's random illegal-instr seed, not deterministic.
+# PMP CSR reads (cve2_cs_registers.sv:361-384): PMPEnable=0 on this core, so
+# each of these is legal at the decoder/case-selection level (case items are
+# genuinely reachable, not gated) but illegal_csr gets forced true afterward
+# (cve2_cs_registers.sv:478-486) -- traps the same way as mseccfg above.
+.word(0x3A001073) # csrrw x0,pmpcfg0,x0
+.word(0x3A101073) # csrrw x0,pmpcfg1,x0
+.word(0x3A201073) # csrrw x0,pmpcfg2,x0
+.word(0x3A301073) # csrrw x0,pmpcfg3,x0
+.word(0x3B001073) # csrrw x0,pmpaddr0,x0
+.word(0x3B101073) # csrrw x0,pmpaddr1,x0
+.word(0x3B201073) # csrrw x0,pmpaddr2,x0
+.word(0x3B301073) # csrrw x0,pmpaddr3,x0
+.word(0x3B401073) # csrrw x0,pmpaddr4,x0
+.word(0x3B501073) # csrrw x0,pmpaddr5,x0
+.word(0x3B601073) # csrrw x0,pmpaddr6,x0
+.word(0x3B701073) # csrrw x0,pmpaddr7,x0
+.word(0x3B801073) # csrrw x0,pmpaddr8,x0
+.word(0x3B901073) # csrrw x0,pmpaddr9,x0
+.word(0x3BA01073) # csrrw x0,pmpaddr10,x0
+.word(0x3BB01073) # csrrw x0,pmpaddr11,x0
+.word(0x3BC01073) # csrrw x0,pmpaddr12,x0
+.word(0x3BD01073) # csrrw x0,pmpaddr13,x0
+.word(0x3BE01073) # csrrw x0,pmpaddr14,x0
+.word(0x3BF01073) # csrrw x0,pmpaddr15,x0
+.word(0x75701073) # csrrw x0,mseccfgh,x0 -- PMPEnable=0 on this core, so mseccfgh (0x757) is always illegal_csr
+# OP-IMM funct3=001, [31:27]=0_1100 sub-case (cve2_decoder.sv:381-397): case
+# entry itself is reachable (raw instr bits, no upstream gate), only the
+# body's RV32B!=RV32BNone ternary is gated -- same category as orc.b above.
+.word(0x60101013) # ctz      [26:20]=0000001
+.word(0x60201013) # cpop     [26:20]=0000010
+.word(0x60401013) # sext.b   [26:20]=0000100
+.word(0x60501013) # sext.h   [26:20]=0000101
+.word(0x61101013) # crc32.h  [26:20]=0010001
+.word(0x61201013) # crc32.w  [26:20]=0010010
+.word(0x61801013) # crc32c.b [26:20]=0011000
+.word(0x61901013) # crc32c.h [26:20]=0011001
+.word(0x61A01013) # crc32c.w [26:20]=0011010
+# cve2_compressed_decoder.sv:168-171: C1/MISC-ALU {instr[12],instr[6:5]}==100/101
+# (c.subw/c.addw) -- reserved on RV32 (RV64/RV128-only mnemonics), same
+# unconditional illegal_instr_o=1 body as the 110/111 case.
+.half(0x9C01) # c.subw slot [15:13]=100,[12]=1,[11:10]=11,[6:5]=00
+.half(0x9C21) # c.addw slot [15:13]=100,[12]=1,[11:10]=11,[6:5]=01
+# 2026-08-13: line 170 (110 slot) flipped to a miss on a fresh corev_rand_illegal_instr_test
+# seed (was previously hit only by random stimulus, never hand-built). Closed
+# deterministically the same way as the other slots in this group -- see
+# docs/RTL-STATEMENT-COVERAGE-AUDIT.md for the seed-variance history.
+.half(0x9C41) # reserved slot [15:13]=100,[12]=1,[11:10]=11,[6:5]=10
+# 2026-08-14: fresh-from-scratch regression exposed 3 more misses relying only on random
+# stimulus, never hand-built -- same seed-variance pattern as above:
+#   cve2_compressed_decoder.sv:171 -- the 111 sibling of the 100/101/110 group just above
+#   cve2_compressed_decoder.sv:121 -- C1 c.lui reserved when nzimm==0 ({instr[12],instr[6:2]}==0)
+#   cve2_compressed_decoder.sv:133 -- C1 c.srli/c.srai reserved when shamt[5](instr[12])==1 on RV32
+# See docs/RTL-STATEMENT-COVERAGE-AUDIT.md for the seed-variance history.
+.half(0x9C61) # reserved slot [15:13]=100,[12]=1,[11:10]=11,[6:5]=11
+.half(0x6081) # c.lui rd=x1, nzimm=0 -- RESERVED, cve2_compressed_decoder.sv:121
+.half(0x9005) # c.srli rd'=x8, shamt[5]=1 -- RESERVED on RV32, cve2_compressed_decoder.sv:133
 
     lw      x5,80(sp)
     bne     x5, x6, fail
@@ -47739,7 +47799,7 @@ main:
     lw      x5,4(sp)
     bne     x5, x25, fail
     addi    sp,sp,84
-    li x16, 47595      # this is the number of EXPECTED illegal instructions
+    li x16, 47635      # this is the number of EXPECTED illegal instructions
     beq x31, x16, test_end
 fail:
     TEST_FAIL          # mismatch: signal failure (write 1) and halt
@@ -47753,7 +47813,18 @@ u_sw_irq_handler:
     li x28, 2
     bne x30, x28, _exit
     csrrc x27, mepc, x0
-    c.addi x27, 4
+    # Advance mepc by 2 or 4 depending on whether the trapping instruction at
+    # mepc is compressed (bits[1:0] != 3) or not -- same detection the shared
+    # bsp/handlers.S u_sw_irq_handler uses. Needed once this file's .word
+    # (32-bit) list gained a .half (16-bit) entry; previously every entry was
+    # exactly 4 bytes so a fixed +4 was safe.
+    lb    x26, 0(x27)
+    andi  x26, x26, 0x3
+    li    x28, 0x3
+    bne   x26, x28, 1f
+    c.addi x27, 2
+1:
+    c.addi x27, 2
     csrrw x0, mepc, x27
     c.addi x31, 1
     mret

--- a/tests/programs/custom/interrupt_bootstrap/interrupt_bootstrap.c
+++ b/tests/programs/custom/interrupt_bootstrap/interrupt_bootstrap.c
@@ -232,7 +232,17 @@ int test1() {
 // To share implementation of basic interrupt test with vector relocation tests,
 // break out the test 1 implementation here
 int test1_impl(int direct_mode) {
-    for (uint32_t i = 0; i < 32; i++) {
+    // i == 0 is irq_uvma[0] == NMI (uvmt_cv32e20_dut_wrap.sv irq_nm_i), not a
+    // maskable line -- it doesn't belong in IRQ_MASK/mie/mip the way i=1..31
+    // do, and this loop's "assert once, wait, clear at the end of the
+    // mie/gmie sub-iteration" model assumes a maskable interrupt that only
+    // fires once mie/gmie both permit it. NMI ignores mie/mstatus.MIE
+    // entirely and retriggers on every mret while the line is held, so it
+    // needs its own dedicated stimulus that deasserts promptly once acked
+    // (see uvme_cv32e20_nmi_assert_c) rather than a level held across this
+    // loop's full 20-iteration delay window -- covered separately by
+    // tests/programs/custom/nmi_test. Skip it here.
+    for (uint32_t i = 1; i < 32; i++) {
 #ifdef DEBUG_MSG
         printf("Test1 -> Testing interrupt %lu\n", i);
 #endif

--- a/tests/programs/custom/misalign/test.yaml
+++ b/tests/programs/custom/misalign/test.yaml
@@ -2,3 +2,5 @@ name: misalign
 uvm_test: uvmt_$(CV_CORE_LC)_firmware_test_c
 description: >
     Misaligned instruction directed test
+plusargs: >
+    +max_both_stall

--- a/tests/programs/custom/nmi_test/nmi_test.c
+++ b/tests/programs/custom/nmi_test/nmi_test.c
@@ -1,0 +1,60 @@
+/*
+** NMI directed test (CV32E20).
+**
+** Confirms the DUT correctly takes a non-maskable interrupt (irq_nm_i,
+** wired to irq_uvma[0] in uvmt_cv32e20_dut_wrap.sv) and returns cleanly.
+**
+** The NMI itself is injected by the testbench, not this program: run with
+** +nmi_assert (see uvmt_cv32e20_general_purpose_test_c::nmi_assert(),
+** which starts uvme_cv32e20_nmi_assert_c) to have the environment assert
+** irq_uvma[0] once, after a bounded random delay, and hold it until acked.
+**
+** This program just busy-waits polling nmi_count (incremented by
+** bsp/handlers.S's m_nmi_irq_handler each time it's entered -- see that
+** file for why NMI needs a real, non-looping handler now) with a bounded
+** local timeout, so a failure to take the NMI is reported as a clean
+** TEST_FAILED rather than relying on the 100ms global watchdog.
+*/
+
+#include <stdio.h>
+#include <stdint.h>
+
+#include "cv32e20_dv.h"
+
+/* Incremented by bsp/handlers.S's m_nmi_irq_handler. */
+extern volatile uint32_t nmi_count;
+
+/* Generous relative to the nmi_assert vseq's initial_delay distribution
+** (bounded to [0:5000] interrupt-driver clock cycles, see
+** uvme_cv32e20_nmi_assert_vseq.sv) plus ack handshake time. */
+#define NMI_WAIT_TICKS 50000u
+
+int main(void)
+{
+    uint32_t start_ticks;
+    uint32_t before;
+
+    printf("NMI directed test\n");
+
+    before = nmi_count;
+    start_ticks = MM_TICKS_REG;
+
+    while (nmi_count == before) {
+        if ((MM_TICKS_REG - start_ticks) > NMI_WAIT_TICKS) {
+            printf("FAIL: NMI not taken within %u ticks (nmi_count still %u)\n",
+                   NMI_WAIT_TICKS, nmi_count);
+            TEST_FAILED;
+            return 1;
+        }
+    }
+
+    printf("NMI taken and handled (nmi_count=%u)\n", nmi_count);
+
+    /* A second injected NMI (e.g. from -j or a later noise thread) landing
+    ** after this point wouldn't be a failure -- only confirm forward
+    ** progress resumed after the first one, don't over-constrain. */
+    printf("Done\n");
+    printf("SUCCESS\n");
+    TEST_PASSED;
+    return 0;
+}

--- a/tests/programs/custom/nmi_test/test.yaml
+++ b/tests/programs/custom/nmi_test/test.yaml
@@ -1,0 +1,6 @@
+name: nmi_test
+uvm_test: uvmt_$(CV_CORE_LC)_firmware_test_c
+description: >
+    NMI (non-maskable interrupt) directed test
+plusargs: >
+    +nmi_assert

--- a/tests/uvmt/firmware-tests/uvmt_cv32e20_general_purpose_test.sv
+++ b/tests/uvmt/firmware-tests/uvmt_cv32e20_general_purpose_test.sv
@@ -66,6 +66,12 @@ class uvmt_cv32e20_general_purpose_test_c extends uvmt_cv32e20_base_test_c;
    extern virtual task irq_noise();
 
    /**
+    *  Deterministically assert NMI (irq_mask[0]) once, after a bounded
+    *  random delay. See uvme_cv32e20_nmi_assert_vseq.sv.
+    */
+   extern virtual task nmi_assert();
+
+   /**
     *  Randomly assert/deassert fetch_enable_i
     */
    extern virtual task random_fetch_toggle();
@@ -99,6 +105,12 @@ task uvmt_cv32e20_general_purpose_test_c::run_phase(uvm_phase phase);
    if ($test$plusargs("gen_irq_noise")) begin
     fork
       irq_noise();
+    join_none
+   end
+
+   if ($test$plusargs("nmi_assert")) begin
+    fork
+      nmi_assert();
     join_none
    end
 
@@ -210,6 +222,16 @@ task uvmt_cv32e20_general_purpose_test_c::irq_noise();
     break;
   end
 endtask : irq_noise
+
+task uvmt_cv32e20_general_purpose_test_c::nmi_assert();
+  uvme_cv32e20_nmi_assert_c nmi_assert_vseq;
+
+  `uvm_info("TEST", "Starting NMI Assert thread in UVM test", UVM_NONE);
+
+  nmi_assert_vseq = uvme_cv32e20_nmi_assert_c::type_id::create("nmi_assert_vseqr", vsequencer);
+  assert(nmi_assert_vseq.randomize());
+  nmi_assert_vseq.start(vsequencer);
+endtask : nmi_assert
 
 task uvmt_cv32e20_general_purpose_test_c::random_fetch_toggle();
   `uvm_info("TEST", "Starting random_fetch_toggle thread in UVM test", UVM_NONE);


### PR DESCRIPTION
Hi @cairo-caplan, this PR brings in a number of updates to close the code coverage on CV32E20.  It includes updates to the testbench, UVM environment and test-programs.  It is still in draft form as I have included all the comments from Claude verbatim as they might be useful for you in your review.  Once you've had a chance to review and comment on this PR, I will update the comments for brevity (Claude tends to be very verbose).
